### PR TITLE
Move all code into AutoHCK module (namespace)

### DIFF
--- a/bin/auto_hck
+++ b/bin/auto_hck
@@ -6,60 +6,63 @@ require './lib/cli'
 require './lib/project'
 require './lib/engines/engine'
 
-cli = CLI.new
-options = cli.parse(ARGV)
+# AutoHCK module
+module AutoHCK
+  cli = CLI.new
+  options = cli.parse(ARGV)
 
-ENV.store 'LC_ALL', 'en_US.UTF-8'
+  ENV.store 'LC_ALL', 'en_US.UTF-8'
 
-AUTOHCK_RETRIES = 5
+  AUTOHCK_RETRIES = 5
 
-at_exit do
-  @engine&.close
-  @project&.abort
-  @project&.close
-end
-
-def clean_threads
-  Thread.list.each do |thread|
-    thread.exit unless Thread.main.eql?(thread)
+  at_exit do
+    @engine&.close
+    @project&.abort
+    @project&.close
   end
-end
 
-@sigterm = false
-Signal.trap('TERM') do
-  if @sigterm
-    @project.logger.warn('SIGTERM(2) received, aborting...')
+  def self.clean_threads
+    Thread.list.each do |thread|
+      thread.exit unless Thread.main.eql?(thread)
+    end
+  end
+
+  @sigterm = false
+  Signal.trap('TERM') do
+    if @sigterm
+      @project.logger.warn('SIGTERM(2) received, aborting...')
+      Signal.trap('TERM') do
+        @project.logger.warn('SIGTERM(*) received, ignoring...')
+      end
+      @engine&.close unless @engine.nil?
+      @project&.handle_cancel
+      clean_threads
+      exit
+    else
+      @sigterm = true
+      @project.logger.warn('SIGTERM(1) received, aborting if another SIGTERM is'\
+                          ' received in the span of the next one second')
+      Thread.new do
+        sleep 1
+        @sigterm = false
+      end
+    end
+  end
+
+  Thread.abort_on_exception = true
+  Thread.report_on_exception = false
+
+  begin
+    @project = Project.new(options)
+    @engine = Engine.new(@project)
+    @engine.run
+  rescue StandardError => e
     Signal.trap('TERM') do
       @project.logger.warn('SIGTERM(*) received, ignoring...')
     end
-    @engine&.close unless @engine.nil?
-    @project&.handle_cancel
+    @project&.log_exception(e, 'fatal')
+    @project&.handle_error
     clean_threads
-    exit
-  else
-    @sigterm = true
-    @project.logger.warn('SIGTERM(1) received, aborting if another SIGTERM is'\
-                         ' received in the span of the next one second')
-    Thread.new do
-      sleep 1
-      @sigterm = false
-    end
+    raise e
   end
-end
-
-Thread.abort_on_exception = true
-Thread.report_on_exception = false
-
-begin
-  @project = Project.new(options)
-  @engine = Engine.new(@project)
-  @engine.run
-rescue StandardError => e
-  Signal.trap('TERM') do
-    @project.logger.warn('SIGTERM(*) received, ignoring...')
-  end
-  @project&.log_exception(e, 'fatal')
-  @project&.handle_error
-  clean_threads
-  raise e
 end

--- a/lib/auxiliary/diff_checker.rb
+++ b/lib/auxiliary/diff_checker.rb
@@ -12,7 +12,7 @@ module AutoHCK
     def initialize(logger, driver, driver_path, diff)
       @logger = logger
       @driver = driver['short']
-      @diff = diff || driver_path + '/' + DIFF_FILENAME
+      @diff = diff || "#{driver_path}/#{DIFF_FILENAME}"
     end
 
     def load_driver_triggers

--- a/lib/auxiliary/diff_checker.rb
+++ b/lib/auxiliary/diff_checker.rb
@@ -2,42 +2,45 @@
 
 require 'yaml'
 
-# selective trigger class
-class DiffChecker
-  DIFF_FILENAME = 'diff.txt'
-  TRIGGER_YAML = 'triggers.yml'
+# AutoHCK module
+module AutoHCK
+  # selective trigger class
+  class DiffChecker
+    DIFF_FILENAME = 'diff.txt'
+    TRIGGER_YAML = 'triggers.yml'
 
-  def initialize(logger, driver, driver_path, diff)
-    @logger = logger
-    @driver = driver['short']
-    @diff = diff || driver_path + '/' + DIFF_FILENAME
-  end
+    def initialize(logger, driver, driver_path, diff)
+      @logger = logger
+      @driver = driver['short']
+      @diff = diff || driver_path + '/' + DIFF_FILENAME
+    end
 
-  def load_driver_triggers
-    @logger.info('Loading diff checker trigger file')
-    yaml = YAML.safe_load(File.read(TRIGGER_YAML))
-    yaml.select! { |_key, value| value ? value & [@driver, '*'] != [] : false }
-    yaml.keys
-  end
+    def load_driver_triggers
+      @logger.info('Loading diff checker trigger file')
+      yaml = YAML.safe_load(File.read(TRIGGER_YAML))
+      yaml.select! { |_key, value| value ? value & [@driver, '*'] != [] : false }
+      yaml.keys
+    end
 
-  def load_diff_files
-    @logger.info('Loading driver diff file')
-    File.readlines(@diff)
-  end
+    def load_diff_files
+      @logger.info('Loading driver diff file')
+      File.readlines(@diff)
+    end
 
-  def root_trigger?(triggers, files)
-    triggers.include?('/') && files.any? { |file| !file.include?('/') }
-  end
+    def root_trigger?(triggers, files)
+      triggers.include?('/') && files.any? { |file| !file.include?('/') }
+    end
 
-  def subdir_trigger?(triggers, files)
-    files.any? { |line| triggers.any? { |trigger| line.start_with?(trigger) } }
-  end
+    def subdir_trigger?(triggers, files)
+      files.any? { |line| triggers.any? { |trigger| line.start_with?(trigger) } }
+    end
 
-  def trigger?
-    return true unless File.file?(@diff) && File.file?(TRIGGER_YAML)
+    def trigger?
+      return true unless File.file?(@diff) && File.file?(TRIGGER_YAML)
 
-    files = load_diff_files
-    triggers = load_driver_triggers
-    root_trigger?(triggers, files) || subdir_trigger?(triggers, files)
+      files = load_diff_files
+      triggers = load_driver_triggers
+      root_trigger?(triggers, files) || subdir_trigger?(triggers, files)
+    end
   end
 end

--- a/lib/auxiliary/github.rb
+++ b/lib/auxiliary/github.rb
@@ -2,101 +2,104 @@
 
 require 'octokit'
 
-# github class
-class Github
-  def initialize(config, logger, url, tag, commit)
-    @api_connected = false
-    @logger = logger
-    @target_url = url
-    @repo = config['repository']
-    @commit = commit.to_s
-    @context = "HCK-CI/#{tag}"
-    connect unless @commit.empty?
-  end
-
-  def connect
-    login = ENV['AUTOHCK_GITHUB_LOGIN']
-    password = ENV['AUTOHCK_GITHUB_TOKEN']
-    @github = Octokit::Client.new(login: login, password: password)
-    @logger.info("Connected to github with: #{@github.user.login}")
-    @api_connected = true
-  rescue Octokit::Unauthorized
-    @logger.warn('Github authentication failed')
-    nil
-  end
-
-  def connected?
-    @api_connected
-  end
-
-  def find_pr
-    pr = @github.pulls(@repo).find { |x| x['head']['sha'] == @commit }
-    if pr.nil?
-      @logger.warn('Pull request commit hash not valid, disconnecting github.')
+# AutoHCK module
+module AutoHCK
+  # github class
+  class Github
+    def initialize(config, logger, url, tag, commit)
       @api_connected = false
-      return nil
+      @logger = logger
+      @target_url = url
+      @repo = config['repository']
+      @commit = commit.to_s
+      @context = "HCK-CI/#{tag}"
+      connect unless @commit.empty?
     end
-    unless pr.nil?
-      @logger.info("PR ##{pr['number']}: #{pr['title']}")
-      @logger.info(pr['html_url'])
-    end
-    pr
-  end
 
-  def create_status(state, description)
-    options = { 'context' => @context,
-                'description' => description,
-                'target_url' => @target_url }
-    begin
-      @github.create_status(@repo, @commit, state, options)
-    rescue Faraday::ConnectionFailed
-      @logger.warn('Github server connection error')
+    def connect
+      login = ENV['AUTOHCK_GITHUB_LOGIN']
+      password = ENV['AUTOHCK_GITHUB_TOKEN']
+      @github = Octokit::Client.new(login: login, password: password)
+      @logger.info("Connected to github with: #{@github.user.login}")
+      @api_connected = true
+    rescue Octokit::Unauthorized
+      @logger.warn('Github authentication failed')
+      nil
     end
-    @logger.info('Github status updated')
-  end
 
-  def update(tests_stats)
-    if tests_stats['current'].nil? && tests_stats['inqueue'].zero?
-      if tests_stats['failed'].zero?
-        handle_success
-      else
-        handle_failure(tests_stats['failed'], tests_stats['passed'])
+    def connected?
+      @api_connected
+    end
+
+    def find_pr
+      pr = @github.pulls(@repo).find { |x| x['head']['sha'] == @commit }
+      if pr.nil?
+        @logger.warn('Pull request commit hash not valid, disconnecting github.')
+        @api_connected = false
+        return nil
       end
-    else
-      handle_pending(tests_stats['currentcount'], tests_stats['total'],
-                     tests_stats['failed'])
+      unless pr.nil?
+        @logger.info("PR ##{pr['number']}: #{pr['title']}")
+        @logger.info(pr['html_url'])
+      end
+      pr
     end
-  end
 
-  def handle_success
-    state = 'success'
-    description = 'All tests passed'
-    create_status(state, description)
-  end
+    def create_status(state, description)
+      options = { 'context' => @context,
+                  'description' => description,
+                  'target_url' => @target_url }
+      begin
+        @github.create_status(@repo, @commit, state, options)
+      rescue Faraday::ConnectionFailed
+        @logger.warn('Github server connection error')
+      end
+      @logger.info('Github status updated')
+    end
 
-  def handle_failure(failed, passed)
-    state = 'failure'
-    description = "#{failed} tests failed out  of #{failed + passed} tests"
-    create_status(state, description)
-  end
+    def update(tests_stats)
+      if tests_stats['current'].nil? && tests_stats['inqueue'].zero?
+        if tests_stats['failed'].zero?
+          handle_success
+        else
+          handle_failure(tests_stats['failed'], tests_stats['passed'])
+        end
+      else
+        handle_pending(tests_stats['currentcount'], tests_stats['total'],
+                       tests_stats['failed'])
+      end
+    end
 
-  def handle_pending(current, total, failed)
-    state = 'pending'
-    description = "Running tests (#{current}/#{total}): #{failed} tests failed"
-    create_status(state, description)
-  end
+    def handle_success
+      state = 'success'
+      description = 'All tests passed'
+      create_status(state, description)
+    end
 
-  def handle_cancel
-    @logger.info('Updating github status regarding cancel')
-    state = 'error'
-    description = 'HCK-CI run was canceled'
-    create_status(state, description)
-  end
+    def handle_failure(failed, passed)
+      state = 'failure'
+      description = "#{failed} tests failed out  of #{failed + passed} tests"
+      create_status(state, description)
+    end
 
-  def handle_error
-    @logger.info('Updating github status regarding error')
-    state = 'error'
-    description = 'An error occurred while running HCK-CI'
-    create_status(state, description)
+    def handle_pending(current, total, failed)
+      state = 'pending'
+      description = "Running tests (#{current}/#{total}): #{failed} tests failed"
+      create_status(state, description)
+    end
+
+    def handle_cancel
+      @logger.info('Updating github status regarding cancel')
+      state = 'error'
+      description = 'HCK-CI run was canceled'
+      create_status(state, description)
+    end
+
+    def handle_error
+      @logger.info('Updating github status regarding error')
+      state = 'error'
+      description = 'An error occurred while running HCK-CI'
+      create_status(state, description)
+    end
   end
 end

--- a/lib/auxiliary/host_helper.rb
+++ b/lib/auxiliary/host_helper.rb
@@ -1,31 +1,37 @@
 # frozen_string_literal: true
 
-def temp_file
-  file = Tempfile.new('')
-  yield(file)
-ensure
-  file.close
-  file.unlink
-end
+# AutoHCK module
+module AutoHCK
+  # Helper module
+  module Helper
+    def temp_file
+      file = Tempfile.new('')
+      yield(file)
+    ensure
+      file.close
+      file.unlink
+    end
 
-def prep_log_stream(stream)
-  stream.strip.lines.map { |line| "\n   -- #{line.rstrip}" }.join
-end
+    def prep_log_stream(stream)
+      stream.strip.lines.map { |line| "\n   -- #{line.rstrip}" }.join
+    end
 
-def log_stdout_stderr(stdout, stderr)
-  @logger.info('Info dump:' + prep_log_stream(stdout)) unless stdout.empty?
-  return if stderr.empty?
+    def log_stdout_stderr(stdout, stderr)
+      @logger.info('Info dump:' + prep_log_stream(stdout)) unless stdout.empty?
+      return if stderr.empty?
 
-  @logger.warn('Error dump:' + prep_log_stream(stderr))
-end
+      @logger.warn('Error dump:' + prep_log_stream(stderr))
+    end
 
-def run_cmd(cmd)
-  temp_file do |stdout|
-    temp_file do |stderr|
-      Process.wait(spawn(cmd.join(' '), out: stdout.path, err: stderr.path))
-      log_stdout_stderr(stdout.read, stderr.read)
-      e_message = "Failed to run: #{cmd.join(' ')}"
-      raise CmdRunError, e_message unless $CHILD_STATUS.exitstatus.zero?
+    def run_cmd(cmd)
+      temp_file do |stdout|
+        temp_file do |stderr|
+          Process.wait(spawn(cmd.join(' '), out: stdout.path, err: stderr.path))
+          log_stdout_stderr(stdout.read, stderr.read)
+          e_message = "Failed to run: #{cmd.join(' ')}"
+          raise CmdRunError, e_message unless $CHILD_STATUS.exitstatus.zero?
+        end
+      end
     end
   end
 end

--- a/lib/auxiliary/host_helper.rb
+++ b/lib/auxiliary/host_helper.rb
@@ -17,10 +17,10 @@ module AutoHCK
     end
 
     def log_stdout_stderr(stdout, stderr)
-      @logger.info('Info dump:' + prep_log_stream(stdout)) unless stdout.empty?
+      @logger.info("Info dump:#{prep_log_stream(stdout)}") unless stdout.empty?
       return if stderr.empty?
 
-      @logger.warn('Error dump:' + prep_log_stream(stderr))
+      @logger.warn("Error dump:#{prep_log_stream(stderr)}")
     end
 
     def run_cmd(cmd)

--- a/lib/auxiliary/id_gen.rb
+++ b/lib/auxiliary/id_gen.rb
@@ -3,81 +3,84 @@
 require 'sqlite3'
 require 'time'
 
-# Id Generator class
-class Idgen
-  def initialize(range, timeout)
-    @db = './id_gen.db'
-    @range = range
-    @conn = SQLite3::Database.new @db.to_s
-    @threshold = timeout * 24 * 60 * 60
-  end
-
-  def load_data
-    ids = Array.new(@range.last + 1 - @range.first, true)
-    @conn.execute 'CREATE TABLE IF NOT EXISTS ActiveIds('\
-                 'IdNumber INT PRIMARY KEY NOT NULL, PID INT NOT NULL,'\
-                 'Time TIMESTAMP NOT NULL)'
-    fetch_data(ids)
-    ids
-  rescue SQLite3::Exception
-    -1
-  end
-
-  def gen_id
-    ids = load_data
-    return -1 if ids == -1
-    return -1 unless ids.index(true)
-
-    release_timeouts
-    ids.index(true) + @range.first
-  end
-
-  def allocate
-    id = gen_id
-    return -1 if id.negative?
-
-    time = Time.now.to_i
-    @conn.execute "INSERT INTO ActiveIds VALUES(#{id},#{Process.pid},#{time})"
-    id
-  rescue SQLite3::ConstraintException
-    retry
-  rescue SQLite3::Exception
-    -1
-  end
-
-  def release(id)
-    @conn.execute "DELETE FROM ActiveIds WHERE IdNumber=#{id}"
-    1
-  rescue SQLite3::Exception
-    -1
-  ensure
-    @conn&.close
-  end
-
-  private
-
-  def release_timeouts
-    now = Time.now.to_i
-    kill_if_alive(now)
-    @conn.execute "DELETE FROM ActiveIds WHERE (#{now} - Time) > #{@threshold}"
-  rescue SQLite3::Exception
-    -1
-  end
-
-  def fetch_data(ids)
-    res = @conn.execute 'SELECT IdNumber FROM ActiveIds'
-    res.each do |row|
-      ids[row[0].to_i - @range.first] = false
+# AutoHCK module
+module AutoHCK
+  # Id Generator class
+  class Idgen
+    def initialize(range, timeout)
+      @db = './id_gen.db'
+      @range = range
+      @conn = SQLite3::Database.new @db.to_s
+      @threshold = timeout * 24 * 60 * 60
     end
-  end
 
-  def kill_if_alive(now)
-    res = @conn.execute 'SELECT PID FROM ActiveIds WHERE'\
-                        "(#{now} - Time) > #{@threshold}"
-    res.each do |row|
-      pid = row[0].to_i
-      check_cmd = "sudo ps -ef | grep #{pid} | grep auto_hck | grep -v grep"
-      Process.kill('TERM', pid) unless `#{check_cmd}`.empty?
+    def load_data
+      ids = Array.new(@range.last + 1 - @range.first, true)
+      @conn.execute 'CREATE TABLE IF NOT EXISTS ActiveIds('\
+                  'IdNumber INT PRIMARY KEY NOT NULL, PID INT NOT NULL,'\
+                  'Time TIMESTAMP NOT NULL)'
+      fetch_data(ids)
+      ids
+    rescue SQLite3::Exception
+      -1
+    end
+
+    def gen_id
+      ids = load_data
+      return -1 if ids == -1
+      return -1 unless ids.index(true)
+
+      release_timeouts
+      ids.index(true) + @range.first
+    end
+
+    def allocate
+      id = gen_id
+      return -1 if id.negative?
+
+      time = Time.now.to_i
+      @conn.execute "INSERT INTO ActiveIds VALUES(#{id},#{Process.pid},#{time})"
+      id
+    rescue SQLite3::ConstraintException
+      retry
+    rescue SQLite3::Exception
+      -1
+    end
+
+    def release(id)
+      @conn.execute "DELETE FROM ActiveIds WHERE IdNumber=#{id}"
+      1
+    rescue SQLite3::Exception
+      -1
+    ensure
+      @conn&.close
+    end
+
+    private
+
+    def release_timeouts
+      now = Time.now.to_i
+      kill_if_alive(now)
+      @conn.execute "DELETE FROM ActiveIds WHERE (#{now} - Time) > #{@threshold}"
+    rescue SQLite3::Exception
+      -1
+    end
+
+    def fetch_data(ids)
+      res = @conn.execute 'SELECT IdNumber FROM ActiveIds'
+      res.each do |row|
+        ids[row[0].to_i - @range.first] = false
+      end
+    end
+
+    def kill_if_alive(now)
+      res = @conn.execute 'SELECT PID FROM ActiveIds WHERE'\
+                          "(#{now} - Time) > #{@threshold}"
+      res.each do |row|
+        pid = row[0].to_i
+        check_cmd = "sudo ps -ef | grep #{pid} | grep auto_hck | grep -v grep"
+        Process.kill('TERM', pid) unless `#{check_cmd}`.empty?
+      end
     end
   end
 end

--- a/lib/auxiliary/json_helper.rb
+++ b/lib/auxiliary/json_helper.rb
@@ -4,9 +4,15 @@ require 'json'
 require 'fileutils'
 require './lib/exceptions'
 
-def read_json(json_file, logger)
-  JSON.parse(File.read(json_file))
-rescue Errno::ENOENT, JSON::ParserError
-  logger.fatal("Could not open #{json_file} file")
-  raise OpenJsonError, "Could not open #{json_file} file"
+# AutoHCK module
+module AutoHCK
+  # Helper module
+  module Helper
+    def read_json(json_file, logger)
+      JSON.parse(File.read(json_file))
+    rescue Errno::ENOENT, JSON::ParserError
+      logger.fatal("Could not open #{json_file} file")
+      raise OpenJsonError, "Could not open #{json_file} file"
+    end
+  end
 end

--- a/lib/auxiliary/multi_logger.rb
+++ b/lib/auxiliary/multi_logger.rb
@@ -1,41 +1,44 @@
 # frozen_string_literal: true
 
-# MultiLogger class
-class MultiLogger
-  attr_reader :level
+# AutoHCK module
+module AutoHCK
+  # MultiLogger class
+  class MultiLogger
+    attr_reader :level
 
-  def initialize(*loggers)
-    @level = Logger::Severity::DEBUG
-    @loggers = []
+    def initialize(*loggers)
+      @level = Logger::Severity::DEBUG
+      @loggers = []
 
-    loggers.each { |logger| add_logger(logger) }
-  end
-
-  def remove_logger(logger)
-    @loggers.delete(logger)
-  end
-
-  def add_logger(logger)
-    logger.level = level
-    @loggers << logger
-  end
-
-  def level=(level)
-    @level = level
-    @loggers.each { |logger| logger.level = level }
-  end
-
-  def close
-    @loggers.map(&:close)
-  end
-
-  Logger::Severity.constants.each do |level|
-    define_method(level.downcase) do |*args, &block|
-      @loggers.each { |logger| logger.send(level.downcase, *args, &block) }
+      loggers.each { |logger| add_logger(logger) }
     end
 
-    define_method("#{level.downcase}?".to_sym) do
-      @level <= Logger::Severity.const_get(level)
+    def remove_logger(logger)
+      @loggers.delete(logger)
+    end
+
+    def add_logger(logger)
+      logger.level = level
+      @loggers << logger
+    end
+
+    def level=(level)
+      @level = level
+      @loggers.each { |logger| logger.level = level }
+    end
+
+    def close
+      @loggers.map(&:close)
+    end
+
+    Logger::Severity.constants.each do |level|
+      define_method(level.downcase) do |*args, &block|
+        @loggers.each { |logger| logger.send(level.downcase, *args, &block) }
+      end
+
+      define_method("#{level.downcase}?".to_sym) do
+        @level <= Logger::Severity.const_get(level)
+      end
     end
   end
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -3,92 +3,95 @@
 require 'optparse'
 require './lib/version'
 
-# class CLI
-class CLI
-  # class ScriptOptions
-  class ScriptOptions
-    attr_accessor :tag, :path, :diff, :commit, :debug
-    def define_options(parser)
-      self.debug = false
-      parser.banner = 'Usage: auto_hck.rb [options]'
-      parser.separator ''
-      mandatory_options(parser)
-      optional_options(parser)
-      parser.on_tail('-h', '--help', 'Show this message') do
-        puts parser
-        exit
+# AutoHCK module
+module AutoHCK
+  # class CLI
+  class CLI
+    # class ScriptOptions
+    class ScriptOptions
+      attr_accessor :tag, :path, :diff, :commit, :debug
+      def define_options(parser)
+        self.debug = false
+        parser.banner = 'Usage: auto_hck.rb [options]'
+        parser.separator ''
+        mandatory_options(parser)
+        optional_options(parser)
+        parser.on_tail('-h', '--help', 'Show this message') do
+          puts parser
+          exit
+        end
+      end
+
+      def mandatory_options(parser)
+        parser.separator 'Mandatory:'
+        tag_option(parser)
+        path_option(parser)
+      end
+
+      def optional_options(parser)
+        parser.separator 'Optional:'
+        commit_option(parser)
+        diff_option(parser)
+        debug_option(parser)
+        version_option(parser)
+      end
+
+      def commit_option(parser)
+        parser.on('-c', '--commit <COMMITHASH>',
+                  'Commit hash for CI status update') do |commit|
+          self.commit = commit
+        end
+      end
+
+      def diff_option(parser)
+        parser.on('-d', '--diff <DIFFFILE>',
+                  'Path to text file containing a list of changed source '\
+                  'files') do |diff|
+          self.diff = diff
+        end
+      end
+
+      def tag_option(parser)
+        parser.on('-t', '--tag [PROJECT-PLATFORM]',
+                  'Tag name consist of project name and platform separated by a '\
+                  'dash') do |tag|
+          self.tag = tag
+        end
+      end
+
+      def path_option(parser)
+        parser.on('-p', '--path [DRIVERPATH]',
+                  'Path to the location of the driver wanted to be '\
+                  'tested') do |path|
+          self.path = path
+        end
+      end
+
+      def debug_option(parser)
+        parser.on('-D', '--debug',
+                  'Printing debug information') do |debug|
+          self.debug = debug
+        end
+      end
+
+      def version_option(parser)
+        parser.on('-V', '--version',
+                  'Display version information and exit') do
+          puts "AutoHCK Version: #{AutoHCK::VERSION}"
+          exit
+        end
       end
     end
 
-    def mandatory_options(parser)
-      parser.separator 'Mandatory:'
-      tag_option(parser)
-      path_option(parser)
-    end
-
-    def optional_options(parser)
-      parser.separator 'Optional:'
-      commit_option(parser)
-      diff_option(parser)
-      debug_option(parser)
-      version_option(parser)
-    end
-
-    def commit_option(parser)
-      parser.on('-c', '--commit <COMMITHASH>',
-                'Commit hash for CI status update') do |commit|
-        self.commit = commit
+    def parse(args)
+      @options = ScriptOptions.new
+      @args = OptionParser.new do |parser|
+        @options.define_options(parser)
+        parser.parse!(args)
       end
+      @options
     end
 
-    def diff_option(parser)
-      parser.on('-d', '--diff <DIFFFILE>',
-                'Path to text file containing a list of changed source '\
-                'files') do |diff|
-        self.diff = diff
-      end
-    end
-
-    def tag_option(parser)
-      parser.on('-t', '--tag [PROJECT-PLATFORM]',
-                'Tag name consist of project name and platform separated by a '\
-                'dash') do |tag|
-        self.tag = tag
-      end
-    end
-
-    def path_option(parser)
-      parser.on('-p', '--path [DRIVERPATH]',
-                'Path to the location of the driver wanted to be '\
-                'tested') do |path|
-        self.path = path
-      end
-    end
-
-    def debug_option(parser)
-      parser.on('-D', '--debug',
-                'Printing debug information') do |debug|
-        self.debug = debug
-      end
-    end
-
-    def version_option(parser)
-      parser.on('-V', '--version',
-                'Display version information and exit') do
-        puts "AutoHCK Version: #{AutoHCK::VERSION}"
-        exit
-      end
-    end
+    attr_reader :parser, :options
   end
-
-  def parse(args)
-    @options = ScriptOptions.new
-    @args = OptionParser.new do |parser|
-      @options.define_options(parser)
-      parser.parse!(args)
-    end
-    @options
-  end
-
-  attr_reader :parser, :options
 end

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -10,6 +10,7 @@ module AutoHCK
     # class ScriptOptions
     class ScriptOptions
       attr_accessor :tag, :path, :diff, :commit, :debug
+
       def define_options(parser)
         self.debug = false
         parser.banner = 'Usage: auto_hck.rb [options]'

--- a/lib/engines/engine.rb
+++ b/lib/engines/engine.rb
@@ -4,47 +4,50 @@ require './lib/engines/exceptions'
 require './lib/setupmanagers/setupmanager'
 require './lib/engines/hcktest/hcktest'
 
-# Engine Class
-#
-class Engine
-  # EngineFactory Class
+# AutoHCK module
+module AutoHCK
+  # Engine Class
   #
-  class EngineFactory
-    ENGINES = {
-      hcktest: HCKTest
-    }.freeze
+  class Engine
+    # EngineFactory Class
+    #
+    class EngineFactory
+      ENGINES = {
+        hcktest: HCKTest
+      }.freeze
 
-    def self.create(type, project)
-      ENGINES[type].new(project)
+      def self.create(type, project)
+        ENGINES[type].new(project)
+      end
+
+      def self.can_create?(type)
+        !ENGINES[type].nil?
+      end
     end
 
-    def self.can_create?(type)
-      !ENGINES[type].nil?
+    def initialize(project)
+      @project = project
+      @logger = project.logger
+      @engine = nil
+      @type = project.engine.downcase.to_sym
+      engine_create
     end
-  end
 
-  def initialize(project)
-    @project = project
-    @logger = project.logger
-    @engine = nil
-    @type = project.engine.downcase.to_sym
-    engine_create
-  end
-
-  def engine_create
-    if EngineFactory.can_create?(@type)
-      @engine = EngineFactory.create(@type, @project)
-    else
-      @logger.warn("Unkown type engine #{@type}, Exiting...")
-      raise InvalidEngineTypeError, "Unkown type engine #{@type}"
+    def engine_create
+      if EngineFactory.can_create?(@type)
+        @engine = EngineFactory.create(@type, @project)
+      else
+        @logger.warn("Unkown type engine #{@type}, Exiting...")
+        raise InvalidEngineTypeError, "Unkown type engine #{@type}"
+      end
     end
-  end
 
-  def run
-    @engine.run
-  end
+    def run
+      @engine.run
+    end
 
-  def close
-    @engine.close
+    def close
+      @engine.close
+    end
   end
 end

--- a/lib/engines/exceptions.rb
+++ b/lib/engines/exceptions.rb
@@ -6,12 +6,16 @@ require './lib/exceptions'
 module AutoHCK
   # A custom EngineError
   class EngineError < AutoHCKError; end
+
   # A custom CmdRun error exception
   class CmdRunError < EngineError; end
+
   # A custom Invalid Paths Error exception
   class InvalidPathError < EngineError; end
+
   # A custom Invalid Config File error exception
   class InvalidConfigFile < EngineError; end
+
   # A custom Invalid Engine Type error exception
   class InvalidEngineTypeError < EngineError; end
 end

--- a/lib/engines/exceptions.rb
+++ b/lib/engines/exceptions.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 require './lib/exceptions'
-# A custom EngineError
-class EngineError < AutoHCKError; end
-# A custom CmdRun error exception
-class CmdRunError < EngineError; end
-# A custom Invalid Paths Error exception
-class InvalidPathError < EngineError; end
-# A custom Invalid Config File error exception
-class InvalidConfigFile < EngineError; end
-# A custom Invalid Engine Type error exception
-class InvalidEngineTypeError < EngineError; end
+
+# AutoHCK module
+module AutoHCK
+  # A custom EngineError
+  class EngineError < AutoHCKError; end
+  # A custom CmdRun error exception
+  class CmdRunError < EngineError; end
+  # A custom Invalid Paths Error exception
+  class InvalidPathError < EngineError; end
+  # A custom Invalid Config File error exception
+  class InvalidConfigFile < EngineError; end
+  # A custom Invalid Engine Type error exception
+  class InvalidEngineTypeError < EngineError; end
+end

--- a/lib/engines/hcktest/hcktest.rb
+++ b/lib/engines/hcktest/hcktest.rb
@@ -4,121 +4,126 @@ require './lib/setupmanagers/hckstudio'
 require './lib/setupmanagers/hckclient'
 require './lib/auxiliary/json_helper'
 
-# HCKTest class
-class HCKTest
-  PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
-  DRIVERS_JSON = 'drivers.json'
-  # This is a temporary workaround for clients names
-  CLIENTS = {
-    CL1: 'c1',
-    CL2: 'c2'
-  }.freeze
-  SM_RETRIES = 5
+# AutoHCK module
+module AutoHCK
+  # HCKTest class
+  class HCKTest
+    include Helper
 
-  def initialize(project)
-    @project = project
-    @platform = read_platform
-    @driver = project.driver
-    init_workspace
-    @setup_manager = SetupManager.new(project)
-    @studio = @setup_manager.create_studio
-    initialize_clients
-  end
+    PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
+    DRIVERS_JSON = 'drivers.json'
+    # This is a temporary workaround for clients names
+    CLIENTS = {
+      CL1: 'c1',
+      CL2: 'c2'
+    }.freeze
+    SM_RETRIES = 5
 
-  def init_workspace
-    @workspace_path = [@project.workspace_path, @platform['name'],
-                       @project.timestamp].join('/')
-    begin
-      FileUtils.mkdir_p(@workspace_path)
-    rescue Errno::EEXIST
-      @project.logger.warn('Workspace path already exists')
+    def initialize(project)
+      @project = project
+      @platform = read_platform
+      @driver = project.driver
+      init_workspace
+      @setup_manager = SetupManager.new(project)
+      @studio = @setup_manager.create_studio
+      initialize_clients
     end
-    @project.move_workspace_to(@workspace_path.to_s)
-  end
 
-  def read_platform
-    platforms = read_json(PLATFORMS_JSON, @project.logger)
-    platform_name = @project.tag.split('-', 2).last
-    @project.logger.info("Loading platform: #{platform_name}")
-    res = platforms.find { |p| p['name'] == platform_name }
-    @project.logger.fatal("#{platform_name} does not exist") unless res
-    res || raise(InvalidConfigFile, "#{platform_name} does not exist")
-  end
-
-  def initialize_clients
-    @clients = {}
-    @platform['clients'].each do |name, client|
-      @clients[client['name']] = @setup_manager.create_client(name,
-                                                              client['name'])
-      break unless @driver['support']
+    def init_workspace
+      @workspace_path = [@project.workspace_path, @platform['name'],
+                         @project.timestamp].join('/')
+      begin
+        FileUtils.mkdir_p(@workspace_path)
+      rescue Errno::EEXIST
+        @project.logger.warn('Workspace path already exists')
+      end
+      @project.move_workspace_to(@workspace_path.to_s)
     end
-    return unless @clients.empty?
 
-    raise InvalidConfigFile, 'Clients configuration for \
-                              this platform is incorrect'
-  end
-
-  def synchronize_clients(exit: false)
-    @clients.each_value do |client|
-      client.synchronize(exit: exit)
+    def read_platform
+      platforms = read_json(PLATFORMS_JSON, @project.logger)
+      platform_name = @project.tag.split('-', 2).last
+      @project.logger.info("Loading platform: #{platform_name}")
+      res = platforms.find { |p| p['name'] == platform_name }
+      @project.logger.fatal("#{platform_name} does not exist") unless res
+      res || raise(InvalidConfigFile, "#{platform_name} does not exist")
     end
-  end
 
-  def configure_clients
-    @clients.values.map(&:configure)
-  end
+    def initialize_clients
+      @clients = {}
+      @platform['clients'].each do |name, client|
+        @clients[client['name']] = @setup_manager.create_client(name,
+                                                                client['name'])
+        break unless @driver['support']
+      end
+      return unless @clients.empty?
 
-  def configure_setup_and_synchronize
-    @studio.configure(@platform['clients'])
-    configure_clients
-    synchronize_clients
-    @client1 = @clients.values[0]
-    @client2 = @clients.values[1]
-    @client1.support = @client2
-  end
-
-  def run_clients
-    @clients.values.map(&:run)
-  end
-
-  def clean_last_run_clients
-    @clients.values.map(&:clean_last_run)
-  end
-
-  def clean_last_run_machines
-    @studio.clean_last_run
-    clean_last_run_clients
-  end
-
-  def run_and_configure_setup
-    retries ||= 0
-    Filelock '/var/tmp/virthck.lock', timeout: 0 do
-      @studio.run
-      run_clients
+      raise InvalidConfigFile, 'Clients configuration for \
+                                this platform is incorrect'
     end
-    configure_setup_and_synchronize
-  rescue AutoHCKError => e
-    synchronize_clients(exit: true)
-    @project.logger.warn("Running and configuring setup failed: (#{e.class}) "\
-                       "#{e.message}")
-    raise e unless (retries += 1) < AUTOHCK_RETRIES
 
-    clean_last_run_machines
-    @setup_manager.close
-    @project.logger.info('Trying again to run and configure setup')
-    retry
-  end
+    def synchronize_clients(exit: false)
+      @clients.each_value do |client|
+        client.synchronize(exit: exit)
+      end
+    end
 
-  def run
-    run_and_configure_setup
-    client = @client1
-    client.run_tests
-    client.create_package
-  end
+    def configure_clients
+      @clients.values.map(&:configure)
+    end
 
-  def close
-    @clients.values.map(&:abort)
-    @studio.abort
-    @setup_manager&.close
+    def configure_setup_and_synchronize
+      @studio.configure(@platform['clients'])
+      configure_clients
+      synchronize_clients
+      @client1 = @clients.values[0]
+      @client2 = @clients.values[1]
+      @client1.support = @client2
+    end
+
+    def run_clients
+      @clients.values.map(&:run)
+    end
+
+    def clean_last_run_clients
+      @clients.values.map(&:clean_last_run)
+    end
+
+    def clean_last_run_machines
+      @studio.clean_last_run
+      clean_last_run_clients
+    end
+
+    def run_and_configure_setup
+      retries ||= 0
+      Filelock '/var/tmp/virthck.lock', timeout: 0 do
+        @studio.run
+        run_clients
+      end
+      configure_setup_and_synchronize
+    rescue AutoHCKError => e
+      synchronize_clients(exit: true)
+      @project.logger.warn("Running and configuring setup failed: (#{e.class}) "\
+                        "#{e.message}")
+      raise e unless (retries += 1) < AUTOHCK_RETRIES
+
+      clean_last_run_machines
+      @setup_manager.close
+      @project.logger.info('Trying again to run and configure setup')
+      retry
+    end
+
+    def run
+      run_and_configure_setup
+      client = @client1
+      client.run_tests
+      client.create_package
+    end
+
+    def close
+      @clients.values.map(&:abort)
+      @studio.abort
+      @setup_manager&.close
+    end
   end
 end

--- a/lib/engines/hcktest/playlist.rb
+++ b/lib/engines/hcktest/playlist.rb
@@ -1,67 +1,70 @@
 # frozen_string_literal: true
 
-# Playlist class
-class Playlist
-  def initialize(client, project, target, tools, kit)
-    @machine = client.name
-    @project = project
-    @target = target
-    @tools = tools
-    @logger = project.logger
-    @kit = kit
-    @ms_playlist = ms_playlist(true)
-  end
-
-  # A custom ListTests error exception
-  class ListTestsError < AutoHCKError; end
-
-  def list_tests(log)
-    @tests = @tools.list_tests(@target['key'], @machine, @project.tag,
-                               @ms_playlist)
-    raise ListTestsError, 'Failed to list tests' unless @tests
-
-    custom_playlist(log)
-    custom_blacklist(log)
-    sort_by_duration
-  end
-
-  def update_target(target)
-    @target = target
-  end
-
-  def ms_playlist(log)
-    kit = @kit
-    file = kit[0..2] == 'HLK' ? "./playlists/#{kit[3..-1]}.xml" : nil
-    return nil if file.nil? || !File.exist?("./#{file}")
-
-    @logger.info("Applying microsoft's playlist") if log
-    file
-  end
-
-  def time_to_seconds(time)
-    time.split(':') .reverse .map .with_index { |a, i| a.to_i * (60**i) }
-        .reduce(:+)
-  end
-
-  def sort_by_duration
-    @tests.each_with_index do |x, i|
-      @tests[i]['duration'] = time_to_seconds(x['estimatedruntime'])
+# AutoHCK module
+module AutoHCK
+  # Playlist class
+  class Playlist
+    def initialize(client, project, target, tools, kit)
+      @machine = client.name
+      @project = project
+      @target = target
+      @tools = tools
+      @logger = project.logger
+      @kit = kit
+      @ms_playlist = ms_playlist(true)
     end
-    @tests.sort_by! { |test| test['duration'] }
-  end
 
-  def custom_playlist(log)
-    playlist = @project.driver['playlist']
-    return unless playlist
+    # A custom ListTests error exception
+    class ListTestsError < AutoHCKError; end
 
-    @tests.select! { |test| playlist.include?(test['name']) }
-    count = @tests.count
-    @logger.info("Applying custom playlist, #{count} tests.") if log
-  end
+    def list_tests(log)
+      @tests = @tools.list_tests(@target['key'], @machine, @project.tag,
+                                 @ms_playlist)
+      raise ListTestsError, 'Failed to list tests' unless @tests
 
-  def custom_blacklist(log)
-    blacklist = @project.driver['blacklist']
-    @tests.reject! { |test| blacklist.include?(test['name']) } if blacklist
-    @logger.info('Applying custom blacklist') if log && blacklist
+      custom_playlist(log)
+      custom_blacklist(log)
+      sort_by_duration
+    end
+
+    def update_target(target)
+      @target = target
+    end
+
+    def ms_playlist(log)
+      kit = @kit
+      file = kit[0..2] == 'HLK' ? "./playlists/#{kit[3..-1]}.xml" : nil
+      return nil if file.nil? || !File.exist?("./#{file}")
+
+      @logger.info("Applying microsoft's playlist") if log
+      file
+    end
+
+    def time_to_seconds(time)
+      time.split(':') .reverse .map .with_index { |a, i| a.to_i * (60**i) }
+          .reduce(:+)
+    end
+
+    def sort_by_duration
+      @tests.each_with_index do |x, i|
+        @tests[i]['duration'] = time_to_seconds(x['estimatedruntime'])
+      end
+      @tests.sort_by! { |test| test['duration'] }
+    end
+
+    def custom_playlist(log)
+      playlist = @project.driver['playlist']
+      return unless playlist
+
+      @tests.select! { |test| playlist.include?(test['name']) }
+      count = @tests.count
+      @logger.info("Applying custom playlist, #{count} tests.") if log
+    end
+
+    def custom_blacklist(log)
+      blacklist = @project.driver['blacklist']
+      @tests.reject! { |test| blacklist.include?(test['name']) } if blacklist
+      @logger.info('Applying custom blacklist') if log && blacklist
+    end
   end
 end

--- a/lib/engines/hcktest/playlist.rb
+++ b/lib/engines/hcktest/playlist.rb
@@ -41,7 +41,7 @@ module AutoHCK
     end
 
     def time_to_seconds(time)
-      time.split(':') .reverse .map .with_index { |a, i| a.to_i * (60**i) }
+      time.split(':').reverse.map.with_index { |a, i| a.to_i * (60**i) }
           .reduce(:+)
     end
 

--- a/lib/engines/hcktest/targets.rb
+++ b/lib/engines/hcktest/targets.rb
@@ -2,55 +2,58 @@
 
 require './lib/exceptions'
 
-# targets class
-class Targets
-  TARGET_RETIRES = 5
-  def initialize(client, project, tools, pool)
-    @machine = client.name
-    @client = client
-    @project = project
-    @name = project.driver['name']
-    @type = project.driver['type']
-    @tools = tools
-    @pool = pool
-    @logger = project.logger
-  end
-
-  # A custom Target error exception
-  class TargetError < AutoHCKError; end
-
-  # A custom AddTargetToProjec error exception
-  class AddTargetToProjectError < TargetError; end
-
-  # A custom SearchTarget error exception
-  class SearchTargetError < TargetError; end
-
-  def add_target_to_project
-    retries ||= 0
-    tag = @project.tag
-    target = search_target
-    @logger.info("Adding target #{@name} on #{@machine} to project #{tag}")
-    return target if @tools.create_project_target(target['key'], tag, @machine)
-
-    e_message = "Adding target #{@name} on #{@machine} to project #{tag} failed"
-    raise AddTargetToProjectError, e_message
-  rescue TargetError => e
-    @logger.warn(e.message)
-    raise unless (retries += 1) < TARGET_RETIRES
-
-    @logger.info("Reconfiguring client #{@machine}...")
-    @client.reconfigure_machine
-    @logger.info("Trying again to add target #{@name} on #{@machine} to "\
-                 "project #{tag}")
-    retry
-  end
-
-  def search_target
-    @logger.info("Searching for target #{@name} on #{@machine}")
-    @tools.list_machine_targets(@machine, @pool).each do |target|
-      return target if target['name'].eql?(@name) && target['type'].eql?(@type)
+# AutoHCK module
+module AutoHCK
+  # targets class
+  class Targets
+    TARGET_RETIRES = 5
+    def initialize(client, project, tools, pool)
+      @machine = client.name
+      @client = client
+      @project = project
+      @name = project.driver['name']
+      @type = project.driver['type']
+      @tools = tools
+      @pool = pool
+      @logger = project.logger
     end
 
-    raise SearchTargetError, "Target #{@name} not found on #{@machine}"
+    # A custom Target error exception
+    class TargetError < AutoHCKError; end
+
+    # A custom AddTargetToProjec error exception
+    class AddTargetToProjectError < TargetError; end
+
+    # A custom SearchTarget error exception
+    class SearchTargetError < TargetError; end
+
+    def add_target_to_project
+      retries ||= 0
+      tag = @project.tag
+      target = search_target
+      @logger.info("Adding target #{@name} on #{@machine} to project #{tag}")
+      return target if @tools.create_project_target(target['key'], tag, @machine)
+
+      e_message = "Adding target #{@name} on #{@machine} to project #{tag} failed"
+      raise AddTargetToProjectError, e_message
+    rescue TargetError => e
+      @logger.warn(e.message)
+      raise unless (retries += 1) < TARGET_RETIRES
+
+      @logger.info("Reconfiguring client #{@machine}...")
+      @client.reconfigure_machine
+      @logger.info("Trying again to add target #{@name} on #{@machine} to "\
+                  "project #{tag}")
+      retry
+    end
+
+    def search_target
+      @logger.info("Searching for target #{@name} on #{@machine}")
+      @tools.list_machine_targets(@machine, @pool).each do |target|
+        return target if target['name'].eql?(@name) && target['type'].eql?(@type)
+      end
+
+      raise SearchTargetError, "Target #{@name} not found on #{@machine}"
+    end
   end
 end

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -1,205 +1,209 @@
 # frozen_string_literal: true
 
 require './lib/engines/hcktest/playlist'
-# Tests class
-class Tests
-  HANDLE_TESTS_POLLING_INTERVAL = 10
-  APPLYING_FILTERS_INTERVAL = 50
-  VERIFY_TARGET_RETRIES = 5
-  VERIFY_TARGET_SLEEP = 5
-  def initialize(client, support, project, target, tools)
-    @client = client
-    @project = project
-    @tag = project.tag
-    @target = target
-    @tools = tools
-    @support = support
-    @logger = project.logger
-    @playlist = Playlist.new(client, project, target, tools, @client.kit)
-  end
 
-  def list_tests(log = false)
-    retries ||= 0
-    @tests = @playlist.list_tests(log)
-  rescue Playlist::ListTestsError => e
-    @logger.warn(e.message)
-    @logger.info('Reconnecting tools...')
-    @tools.reconnect
-    raise unless (retries += 1) == 1 || verify_target
-
-    @logger.info('Trying again to list tests')
-    retry
-  end
-
-  def verify_target
-    retries ||= 0
-    @logger.info('Verifying target...')
-    target = Targets.new(@client, @project, @tools, @tag).search_target
-    return false if target.eql?(@target)
-
-    @logger.info('Target changed, updating...')
-    @target = target
-    @playlist.update_target(target)
-    true
-  rescue Targets::SearchTargetError => e
-    @logger.warn(e.message)
-    raise unless (retries += 1) < VERIFY_TARGET_RETRIES
-
-    sleep VERIFY_TARGET_SLEEP
-    @logger.info('Trying again to verify target')
-    retry
-  end
-
-  def support_needed?(test)
-    (test['scheduleoptions'] & %w[6 RequiresMultipleMachines]) != []
-  end
-
-  def test_support(test)
-    @support.name if support_needed?(test)
-  end
-
-  def queue_test(test)
-    @tools.queue_test(test['id'], @target['key'], @client.name, @tag,
-                      test_support(test))
-  end
-
-  def current_test
-    @tests.find { |test| test['executionstate'] == 'Running' }
-  end
-
-  def status_count(status)
-    @tests.count { |test| test['status'] == status }
-  end
-
-  def tests_stats
-    { 'current' => current_test, 'passed' => status_count('Passed'),
-      'failed' => status_count('Failed'), 'inqueue' => status_count('InQueue'),
-      'currentcount' => done_tests.count + 1, 'total' => @total }
-  end
-
-  def done_tests
-    @tests.select { |test| %w[Passed Failed].include? test['status'] }
-  end
-
-  def info_page(test)
-    url = 'https://docs.microsoft.com/en-us/windows-hardware/test/hlk/testref/'
-    "Test information page: #{url}#{test['id']}"
-  end
-
-  def print_test_info_when_start(test)
-    @logger.info('>>> Currently running: '\
-                 "#{test['name']} [#{test['estimatedruntime']}]")
-  end
-
-  def print_tests_stats
-    stats = tests_stats
-    @logger.info("<<< Passed: #{stats['passed']} | Failed: #{stats['failed']} |\
-InQueue: #{stats['inqueue']}")
-  end
-
-  def print_test_results(test)
-    results = @tests.find { |t| t['id'] == test['id'] }
-    @logger.info(results['status'] + ': ' + test['name'])
-    @logger.info(info_page(test))
-  end
-
-  def archive_test_results(test)
-    res = @tools.zip_test_result_logs(test['id'], @target['key'], @client.name,
-                                      @tag)
-    @logger.info('Test archive successfully created')
-    update_remote(res['hostlogszippath'], res['status'], res['testname'])
-    @logger.info('Test archive uploaded via the result uploader')
-  rescue Tools::ZipTestResultLogsError
-    @logger.info('Skipping archiving test result logs')
-  end
-
-  def update_remote(test_logs_path, status, testname)
-    delete_old_remote(testname)
-    new_filename = status + ': ' + testname
-    r_name = new_filename + File.extname(test_logs_path)
-    @project.result_uploader.upload_file(test_logs_path, r_name)
-    logs = @tests.reduce('') do |sum, test|
-      sum + "#{test['status']}: #{test['name']}\n"
+# AutoHCK module
+module AutoHCK
+  # Tests class
+  class Tests
+    HANDLE_TESTS_POLLING_INTERVAL = 10
+    APPLYING_FILTERS_INTERVAL = 50
+    VERIFY_TARGET_RETRIES = 5
+    VERIFY_TARGET_SLEEP = 5
+    def initialize(client, support, project, target, tools)
+      @client = client
+      @project = project
+      @tag = project.tag
+      @target = target
+      @tools = tools
+      @support = support
+      @logger = project.logger
+      @playlist = Playlist.new(client, project, target, tools, @client.kit)
     end
-    @logger.info('Tests results logs updated via the result uploader')
-    @project.result_uploader.update_file_content(logs, 'logs.txt')
-  end
 
-  def delete_old_remote(test_name)
-    r_name = 'Failed: ' + test_name + '.zip'
-    @project.result_uploader.delete_file(r_name)
-    r_name = 'Passed: ' + test_name + '.zip'
-    @project.result_uploader.delete_file(r_name)
-  end
+    def list_tests(log = false)
+      retries ||= 0
+      @tests = @playlist.list_tests(log)
+    rescue Playlist::ListTestsError => e
+      @logger.warn(e.message)
+      @logger.info('Reconnecting tools...')
+      @tools.reconnect
+      raise unless (retries += 1) == 1 || verify_target
 
-  def all_tests_finished?
-    status_count('InQueue').zero? && current_test.nil?
-  end
-
-  def handle_finished_tests(tests)
-    tests.each do |test|
-      @project.github.update(tests_stats) if @project.github&.connected?
-      print_test_results(test)
-      archive_test_results(test)
+      @logger.info('Trying again to list tests')
+      retry
     end
-    print_tests_stats
-  end
 
-  def reset_clients_to_ready_state
-    @client.reset_to_ready_state
-    @support&.reset_to_ready_state
-  end
+    def verify_target
+      retries ||= 0
+      @logger.info('Verifying target...')
+      target = Targets.new(@client, @project, @tools, @tag).search_target
+      return false if target.eql?(@target)
 
-  def keep_clients_alive
-    @client.keep_alive
-    @support&.keep_alive
-  end
+      @logger.info('Target changed, updating...')
+      @target = target
+      @playlist.update_target(target)
+      true
+    rescue Targets::SearchTargetError => e
+      @logger.warn(e.message)
+      raise unless (retries += 1) < VERIFY_TARGET_RETRIES
 
-  def new_done
-    list_tests
-    done_tests - @last_done
-  end
+      sleep VERIFY_TARGET_SLEEP
+      @logger.info('Trying again to verify target')
+      retry
+    end
 
-  def apply_filters
-    @logger.info('Applying filters on finished tests')
-    @tools.apply_project_filters(@tag)
-    sleep APPLYING_FILTERS_INTERVAL
-  end
+    def support_needed?(test)
+      (test['scheduleoptions'] & %w[6 RequiresMultipleMachines]) != []
+    end
 
-  def check_new_finished_tests
-    return unless new_done.any?
+    def test_support(test)
+      @support.name if support_needed?(test)
+    end
 
-    apply_filters
-    handle_finished_tests(new_done)
-  end
+    def queue_test(test)
+      @tools.queue_test(test['id'], @target['key'], @client.name, @tag,
+                        test_support(test))
+    end
 
-  def handle_test_running(running = nil)
-    @last_done = []
-    until all_tests_finished?
-      keep_clients_alive
-      reset_clients_to_ready_state
-      check_new_finished_tests
-      if current_test != running
-        running = current_test
-        print_test_info_when_start(running) if running
+    def current_test
+      @tests.find { |test| test['executionstate'] == 'Running' }
+    end
+
+    def status_count(status)
+      @tests.count { |test| test['status'] == status }
+    end
+
+    def tests_stats
+      { 'current' => current_test, 'passed' => status_count('Passed'),
+        'failed' => status_count('Failed'), 'inqueue' => status_count('InQueue'),
+        'currentcount' => done_tests.count + 1, 'total' => @total }
+    end
+
+    def done_tests
+      @tests.select { |test| %w[Passed Failed].include? test['status'] }
+    end
+
+    def info_page(test)
+      url = 'https://docs.microsoft.com/en-us/windows-hardware/test/hlk/testref/'
+      "Test information page: #{url}#{test['id']}"
+    end
+
+    def print_test_info_when_start(test)
+      @logger.info('>>> Currently running: '\
+                  "#{test['name']} [#{test['estimatedruntime']}]")
+    end
+
+    def print_tests_stats
+      stats = tests_stats
+      @logger.info("<<< Passed: #{stats['passed']} | Failed: #{stats['failed']} |\
+  InQueue: #{stats['inqueue']}")
+    end
+
+    def print_test_results(test)
+      results = @tests.find { |t| t['id'] == test['id'] }
+      @logger.info(results['status'] + ': ' + test['name'])
+      @logger.info(info_page(test))
+    end
+
+    def archive_test_results(test)
+      res = @tools.zip_test_result_logs(test['id'], @target['key'], @client.name,
+                                        @tag)
+      @logger.info('Test archive successfully created')
+      update_remote(res['hostlogszippath'], res['status'], res['testname'])
+      @logger.info('Test archive uploaded via the result uploader')
+    rescue Tools::ZipTestResultLogsError
+      @logger.info('Skipping archiving test result logs')
+    end
+
+    def update_remote(test_logs_path, status, testname)
+      delete_old_remote(testname)
+      new_filename = status + ': ' + testname
+      r_name = new_filename + File.extname(test_logs_path)
+      @project.result_uploader.upload_file(test_logs_path, r_name)
+      logs = @tests.reduce('') do |sum, test|
+        sum + "#{test['status']}: #{test['name']}\n"
       end
-      @last_done = done_tests
-      sleep HANDLE_TESTS_POLLING_INTERVAL
+      @logger.info('Tests results logs updated via the result uploader')
+      @project.result_uploader.update_file_content(logs, 'logs.txt')
     end
-  end
 
-  def create_project_package
-    res = @tools.create_project_package(@tag)
-    @logger.info('Results package successfully created')
-    r_name = @tag + File.extname(res['hostprojectpackagepath'])
-    @project.result_uploader.upload_file(res['hostprojectpackagepath'], r_name)
-  end
+    def delete_old_remote(test_name)
+      r_name = 'Failed: ' + test_name + '.zip'
+      @project.result_uploader.delete_file(r_name)
+      r_name = 'Passed: ' + test_name + '.zip'
+      @project.result_uploader.delete_file(r_name)
+    end
 
-  def run
-    @total = @tests.count
-    @logger.info('Adding tests to queue')
-    @tests.each { |test| queue_test(test) }
-    list_tests(true)
-    handle_test_running
+    def all_tests_finished?
+      status_count('InQueue').zero? && current_test.nil?
+    end
+
+    def handle_finished_tests(tests)
+      tests.each do |test|
+        @project.github.update(tests_stats) if @project.github&.connected?
+        print_test_results(test)
+        archive_test_results(test)
+      end
+      print_tests_stats
+    end
+
+    def reset_clients_to_ready_state
+      @client.reset_to_ready_state
+      @support&.reset_to_ready_state
+    end
+
+    def keep_clients_alive
+      @client.keep_alive
+      @support&.keep_alive
+    end
+
+    def new_done
+      list_tests
+      done_tests - @last_done
+    end
+
+    def apply_filters
+      @logger.info('Applying filters on finished tests')
+      @tools.apply_project_filters(@tag)
+      sleep APPLYING_FILTERS_INTERVAL
+    end
+
+    def check_new_finished_tests
+      return unless new_done.any?
+
+      apply_filters
+      handle_finished_tests(new_done)
+    end
+
+    def handle_test_running(running = nil)
+      @last_done = []
+      until all_tests_finished?
+        keep_clients_alive
+        reset_clients_to_ready_state
+        check_new_finished_tests
+        if current_test != running
+          running = current_test
+          print_test_info_when_start(running) if running
+        end
+        @last_done = done_tests
+        sleep HANDLE_TESTS_POLLING_INTERVAL
+      end
+    end
+
+    def create_project_package
+      res = @tools.create_project_package(@tag)
+      @logger.info('Results package successfully created')
+      r_name = @tag + File.extname(res['hostprojectpackagepath'])
+      @project.result_uploader.upload_file(res['hostprojectpackagepath'], r_name)
+    end
+
+    def run
+      @total = @tests.count
+      @logger.info('Adding tests to queue')
+      @tests.each { |test| queue_test(test) }
+      list_tests(true)
+      handle_test_running
+    end
   end
 end

--- a/lib/engines/hcktest/tests.rb
+++ b/lib/engines/hcktest/tests.rb
@@ -102,7 +102,7 @@ module AutoHCK
 
     def print_test_results(test)
       results = @tests.find { |t| t['id'] == test['id'] }
-      @logger.info(results['status'] + ': ' + test['name'])
+      @logger.info("#{results['status']}: #{test['name']}")
       @logger.info(info_page(test))
     end
 
@@ -118,7 +118,7 @@ module AutoHCK
 
     def update_remote(test_logs_path, status, testname)
       delete_old_remote(testname)
-      new_filename = status + ': ' + testname
+      new_filename = "#{status}: #{testname}"
       r_name = new_filename + File.extname(test_logs_path)
       @project.result_uploader.upload_file(test_logs_path, r_name)
       logs = @tests.reduce('') do |sum, test|
@@ -129,9 +129,9 @@ module AutoHCK
     end
 
     def delete_old_remote(test_name)
-      r_name = 'Failed: ' + test_name + '.zip'
+      r_name = "Failed: #{test_name}.zip"
       @project.result_uploader.delete_file(r_name)
-      r_name = 'Passed: ' + test_name + '.zip'
+      r_name = "Passed: #{test_name}.zip"
       @project.result_uploader.delete_file(r_name)
     end
 

--- a/lib/engines/hcktest/tools.rb
+++ b/lib/engines/hcktest/tools.rb
@@ -23,8 +23,10 @@ module AutoHCK
               outp_dir: project.workspace_path,
               l_script_file: @config['toolshck_path'])
     end
+
     # A custom InvalidToolsPath error exception
     class InvalidToolsPathError < AutoHCKError; end
+
     # A custom ZipTestResultLogs error exception
     class ZipTestResultLogsError < AutoHCKError; end
 

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
-# A custom AutoHCK error exception
-class AutoHCKError < StandardError; end
+# AutoHCK module
+module AutoHCK
+  # A custom AutoHCK error exception
+  class AutoHCKError < StandardError; end
 
-# A custom GithubCommitInvalid error exception
-class GithubCommitInvalid < AutoHCKError; end
+  # A custom GithubCommitInvalid error exception
+  class GithubCommitInvalid < AutoHCKError; end
 
-# A custom Could not open json file exception
-class OpenJsonError < StandardError; end
+  # A custom Could not open json file exception
+  class OpenJsonError < StandardError; end
+end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -18,6 +18,7 @@ module AutoHCK
 
     attr_reader :config, :logger, :timestamp, :setupmanager, :engine, :tag, :id,
                 :driver, :driver_path, :workspace_path, :github, :result_uploader
+
     DRIVERS_JSON = './drivers.json'
     CONFIG_JSON = 'config.json'
 

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -10,172 +10,177 @@ require './lib/auxiliary/diff_checker'
 require './lib/auxiliary/json_helper'
 require './lib/auxiliary/id_gen'
 
-# project class
-class Project
-  attr_reader :config, :logger, :timestamp, :setupmanager, :engine, :tag, :id,
-              :driver, :driver_path, :workspace_path, :github, :result_uploader
-  DRIVERS_JSON = './drivers.json'
-  CONFIG_JSON = 'config.json'
+# AutoHCK module
+module AutoHCK
+  # project class
+  class Project
+    include Helper
 
-  def initialize(options)
-    init_multilog(options.debug)
-    init_class_variables(options)
-    validate_paths
-    diff_checker(options.diff)
-    configure_result_uploader
-    github_handling(options.commit)
-    init_workspace
-    append_multilog
-    @id = assign_id
-  end
+    attr_reader :config, :logger, :timestamp, :setupmanager, :engine, :tag, :id,
+                :driver, :driver_path, :workspace_path, :github, :result_uploader
+    DRIVERS_JSON = './drivers.json'
+    CONFIG_JSON = 'config.json'
 
-  def diff_checker(diff)
-    diff_checker = DiffChecker.new(@logger, @driver, @driver_path, diff)
-    return if diff_checker.trigger?
+    def initialize(options)
+      init_multilog(options.debug)
+      init_class_variables(options)
+      validate_paths
+      diff_checker(options.diff)
+      configure_result_uploader
+      github_handling(options.commit)
+      init_workspace
+      append_multilog
+      @id = assign_id
+    end
 
-    @logger.info("Driver isn't changed, not running tests")
-    exit(0)
-  end
+    def diff_checker(diff)
+      diff_checker = DiffChecker.new(@logger, @driver, @driver_path, diff)
+      return if diff_checker.trigger?
 
-  def prep_stream_for_log(stream)
-    stream.strip.lines.map { |line| "\n   -- #{line.rstrip}" }.join
-  end
+      @logger.info("Driver isn't changed, not running tests")
+      exit(0)
+    end
 
-  def log_exception(exception, level)
-    eclass = exception.class
-    emessage = exception.message
-    estack = prep_stream_for_log(exception.backtrace.join("\n"))
-    @logger.public_send(level, "(#{eclass}) #{emessage}#{estack}")
-  end
+    def prep_stream_for_log(stream)
+      stream.strip.lines.map { |line| "\n   -- #{line.rstrip}" }.join
+    end
 
-  def init_multilog(debug)
-    @temp_pre_logger_file = Tempfile.new('')
-    @temp_pre_logger_file.sync = true
-    @pre_logger = MonoLogger.new(@temp_pre_logger_file)
-    @stdout_logger = MonoLogger.new(STDOUT)
-    @logger = MultiLogger.new(@pre_logger, @stdout_logger)
-    @logger.level = debug ? 'DEBUG' : 'INFO'
-  end
+    def log_exception(exception, level)
+      eclass = exception.class
+      emessage = exception.message
+      estack = prep_stream_for_log(exception.backtrace.join("\n"))
+      @logger.public_send(level, "(#{eclass}) #{emessage}#{estack}")
+    end
 
-  def append_multilog
-    @logfile_path = "#{workspace_path}/#{tag}.log"
-    FileUtils.cp(@temp_pre_logger_file.path, @logfile_path)
-    @pre_logger.close
-    @temp_pre_logger_file.unlink
-    @logger.remove_logger(@pre_logger)
-    @pre_logger = MonoLogger.new(@logfile_path)
-    @logger.add_logger(@pre_logger)
-  end
+    def init_multilog(debug)
+      @temp_pre_logger_file = Tempfile.new('')
+      @temp_pre_logger_file.sync = true
+      @pre_logger = MonoLogger.new(@temp_pre_logger_file)
+      @stdout_logger = MonoLogger.new(STDOUT)
+      @logger = MultiLogger.new(@pre_logger, @stdout_logger)
+      @logger.level = debug ? 'DEBUG' : 'INFO'
+    end
 
-  def move_workspace_to(path)
-    FileUtils.cp(@logfile_path, "#{path}/#{tag}.log")
-    @logfile_path = "#{path}/#{tag}.log"
-    @pre_logger.close
-    @logger.remove_logger(@pre_logger)
-    @pre_logger = MonoLogger.new(@logfile_path)
-    @logger.add_logger(@pre_logger)
-    @workspace_path = path
-  end
+    def append_multilog
+      @logfile_path = "#{workspace_path}/#{tag}.log"
+      FileUtils.cp(@temp_pre_logger_file.path, @logfile_path)
+      @pre_logger.close
+      @temp_pre_logger_file.unlink
+      @logger.remove_logger(@pre_logger)
+      @pre_logger = MonoLogger.new(@logfile_path)
+      @logger.add_logger(@pre_logger)
+    end
 
-  def init_class_variables(options)
-    @config = read_json(CONFIG_JSON, @logger)
-    @timestamp = create_timestamp
-    @tag = options.tag
-    @driver_path = options.path
-    @driver = find_driver
-    @engine = @config['engine']
-    @setupmanager = @config['setupmanager']
-  end
+    def move_workspace_to(path)
+      FileUtils.cp(@logfile_path, "#{path}/#{tag}.log")
+      @logfile_path = "#{path}/#{tag}.log"
+      @pre_logger.close
+      @logger.remove_logger(@pre_logger)
+      @pre_logger = MonoLogger.new(@logfile_path)
+      @logger.add_logger(@pre_logger)
+      @workspace_path = path
+    end
 
-  def assign_id
-    @id_gen = Idgen.new(@config['id_range'], @config['time_out'])
-    id = @id_gen.allocate
-    while id.negative?
-      @logger.info('No available ID')
-      sleep 20
+    def init_class_variables(options)
+      @config = read_json(CONFIG_JSON, @logger)
+      @timestamp = create_timestamp
+      @tag = options.tag
+      @driver_path = options.path
+      @driver = find_driver
+      @engine = @config['engine']
+      @setupmanager = @config['setupmanager']
+    end
+
+    def assign_id
+      @id_gen = Idgen.new(@config['id_range'], @config['time_out'])
       id = @id_gen.allocate
+      while id.negative?
+        @logger.info('No available ID')
+        sleep 20
+        id = @id_gen.allocate
+      end
+      @logger.info("Assigned ID: #{id}")
+      id.to_s
     end
-    @logger.info("Assigned ID: #{id}")
-    id.to_s
-  end
 
-  def release_id
-    @logger.info("Releasing ID: #{@id}")
-    @id_gen.release(@id)
-  end
-
-  def configure_result_uploader
-    @logger.info('Initializing result uploaders')
-    @result_uploader = ResultUploader.new(self)
-    @result_uploader.connect
-    @result_uploader.create_project_folder
-  end
-
-  def github_handling(commit)
-    return if commit.to_s.empty?
-
-    @github = Github.new(@config, @logger, @result_uploader.url, @tag, commit)
-    raise GithubCommitInvalid unless @github.connected?
-
-    @github.find_pr
-    raise GithubCommitInvalid unless @github.connected?
-
-    @github.create_status('pending', 'Tests session initiated')
-  end
-
-  def validate_paths
-    normalize_paths
-    return if File.exist?("#{@driver_path}/#{@driver['inf']}")
-
-    @logger.fatal('Driver path is not valid')
-    exit(1)
-  end
-
-  def normalize_paths
-    @driver_path.chomp!('/')
-  end
-
-  def find_driver
-    drivers = read_json(DRIVERS_JSON, @logger)
-    short_name = @tag.split('-', 2).first
-    @logger.info("Loading driver: #{short_name}")
-    res = drivers.find { |driver| driver['short'] == short_name }
-    logger.fatal("#{short_name} does not exist") unless res
-    res || exit(1)
-  end
-
-  def create_timestamp
-    Time.now.strftime('%Y_%m_%d_%H_%M_%S')
-  end
-
-  def init_workspace
-    @workspace_path = [@config['workspace_path'], @driver['short'],
-                       @config['engine'], @config['setupmanager']].join('/')
-    begin
-      FileUtils.mkdir_p(@workspace_path)
-    rescue Errno::EEXIST
-      @logger.warn('Workspace path already exists')
+    def release_id
+      @logger.info("Releasing ID: #{@id}")
+      @id_gen.release(@id)
     end
-  end
 
-  def handle_cancel
-    @github.handle_cancel if @github&.connected?
-  end
+    def configure_result_uploader
+      @logger.info('Initializing result uploaders')
+      @result_uploader = ResultUploader.new(self)
+      @result_uploader.connect
+      @result_uploader.create_project_folder
+    end
 
-  def handle_error
-    @github.handle_error if @github&.connected?
-  end
+    def github_handling(commit)
+      return if commit.to_s.empty?
 
-  def abort
-    @result_uploader.upload_file(@logfile_path, 'AutoHCK.log')
-    @logger.remove_logger(@stdout_logger)
-  end
+      @github = Github.new(@config, @logger, @result_uploader.url, @tag, commit)
+      raise GithubCommitInvalid unless @github.connected?
 
-  def close
-    @client1&.abort
-    @client2&.abort
-    @studio&.abort
-    @setup_manager&.close
-    release_id
+      @github.find_pr
+      raise GithubCommitInvalid unless @github.connected?
+
+      @github.create_status('pending', 'Tests session initiated')
+    end
+
+    def validate_paths
+      normalize_paths
+      return if File.exist?("#{@driver_path}/#{@driver['inf']}")
+
+      @logger.fatal('Driver path is not valid')
+      exit(1)
+    end
+
+    def normalize_paths
+      @driver_path.chomp!('/')
+    end
+
+    def find_driver
+      drivers = read_json(DRIVERS_JSON, @logger)
+      short_name = @tag.split('-', 2).first
+      @logger.info("Loading driver: #{short_name}")
+      res = drivers.find { |driver| driver['short'] == short_name }
+      logger.fatal("#{short_name} does not exist") unless res
+      res || exit(1)
+    end
+
+    def create_timestamp
+      Time.now.strftime('%Y_%m_%d_%H_%M_%S')
+    end
+
+    def init_workspace
+      @workspace_path = [@config['workspace_path'], @driver['short'],
+                         @config['engine'], @config['setupmanager']].join('/')
+      begin
+        FileUtils.mkdir_p(@workspace_path)
+      rescue Errno::EEXIST
+        @logger.warn('Workspace path already exists')
+      end
+    end
+
+    def handle_cancel
+      @github.handle_cancel if @github&.connected?
+    end
+
+    def handle_error
+      @github.handle_error if @github&.connected?
+    end
+
+    def abort
+      @result_uploader.upload_file(@logfile_path, 'AutoHCK.log')
+      @logger.remove_logger(@stdout_logger)
+    end
+
+    def close
+      @client1&.abort
+      @client2&.abort
+      @studio&.abort
+      @setup_manager&.close
+      release_id
+    end
   end
 end

--- a/lib/resultuploaders/dropbox.rb
+++ b/lib/resultuploaders/dropbox.rb
@@ -47,10 +47,10 @@ module AutoHCK
 
     def create_project_folder
       handle_exceptions(__method__) do
-        @path = '/' + @tag + '-' + @timestamp
+        @path = "/#{@tag}-#{@timestamp}"
         @dropbox.create_folder(@path)
         @dropbox.share_folder(@path)
-        @url = @dropbox.create_shared_link_with_settings(@path).url + '&lst='
+        @url = "#{@dropbox.create_shared_link_with_settings(@path).url}&lst="
         @logger.info("Dropbox project folder created: #{@url}")
       end
     end
@@ -58,14 +58,14 @@ module AutoHCK
     def upload_file(l_path, r_name)
       handle_exceptions(__method__) do
         content = IO.read(l_path)
-        r_path = @path + '/' + r_name
+        r_path = "#{@path}/#{r_name}"
         @dropbox.upload(r_path, content)
       end
     end
 
     def update_file_content(content, r_name)
       handle_exceptions(__method__) do
-        r_path = @path + '/' + r_name
+        r_path = "#{@path}/#{r_name}"
         @dropbox.upload(r_path, content, mode: 'overwrite')
       end
     end
@@ -73,7 +73,7 @@ module AutoHCK
     def delete_file(r_name)
       handle_exceptions(__method__) do
         begin
-          r_path = @path + '/' + r_name
+          r_path = "#{@path}/#{r_name}"
           @dropbox.delete(r_path)
           @logger.info("Dropbox file deleted: #{r_path}")
           true

--- a/lib/resultuploaders/dropbox.rb
+++ b/lib/resultuploaders/dropbox.rb
@@ -2,83 +2,86 @@
 
 require 'dropbox_api'
 
-# dropbox class
-class Dropbox
-  attr_reader :url
-  def initialize(project)
-    @tag = project.tag
-    @timestamp = project.timestamp
-    @logger = project.logger
-    @token = ENV['AUTOHCK_DROPBOX_TOKEN']
-    @dropbox = nil
-    @url = nil
-  end
-
-  def handle_exceptions(where)
-    if @dropbox.nil?
-      @logger.warn("Dropbox connection error, ignoring #{where}")
-    else
-      yield
+# AutoHCK module
+module AutoHCK
+  # dropbox class
+  class Dropbox
+    attr_reader :url
+    def initialize(project)
+      @tag = project.tag
+      @timestamp = project.timestamp
+      @logger = project.logger
+      @token = ENV['AUTOHCK_DROPBOX_TOKEN']
+      @dropbox = nil
+      @url = nil
     end
-  rescue Faraday::ConnectionFailed
-    @logger.warn("Dropbox connection lost while #{where}")
-    @logger.info('Trying to re-establish the Dropbox connection')
-    connect
-    retry
-  rescue StandardError => e
-    @logger.warn("Dropbox #{where} error: (#{e.class}) #{e.message}")
-  end
 
-  def connect
-    if @token
-      @dropbox = DropboxApi::Client.new(@token)
-      @logger.warn('Dropbox authentication failure') if @dropbox.nil?
-    else
-      @logger.info('Dropbox token missing')
+    def handle_exceptions(where)
+      if @dropbox.nil?
+        @logger.warn("Dropbox connection error, ignoring #{where}")
+      else
+        yield
+      end
+    rescue Faraday::ConnectionFailed
+      @logger.warn("Dropbox connection lost while #{where}")
+      @logger.info('Trying to re-establish the Dropbox connection')
+      connect
+      retry
+    rescue StandardError => e
+      @logger.warn("Dropbox #{where} error: (#{e.class}) #{e.message}")
     end
-    @dropbox.nil? ? false : true
-  rescue DropboxApi::Errors::HttpError
-    @logger.warn('Dropbox connection error')
-    false
-  end
 
-  def create_project_folder
-    handle_exceptions(__method__) do
-      @path = '/' + @tag + '-' + @timestamp
-      @dropbox.create_folder(@path)
-      @dropbox.share_folder(@path)
-      @url = @dropbox.create_shared_link_with_settings(@path).url + '&lst='
-      @logger.info("Dropbox project folder created: #{@url}")
+    def connect
+      if @token
+        @dropbox = DropboxApi::Client.new(@token)
+        @logger.warn('Dropbox authentication failure') if @dropbox.nil?
+      else
+        @logger.info('Dropbox token missing')
+      end
+      @dropbox.nil? ? false : true
+    rescue DropboxApi::Errors::HttpError
+      @logger.warn('Dropbox connection error')
+      false
     end
-  end
 
-  def upload_file(l_path, r_name)
-    handle_exceptions(__method__) do
-      content = IO.read(l_path)
-      r_path = @path + '/' + r_name
-      @dropbox.upload(r_path, content)
-    end
-  end
-
-  def update_file_content(content, r_name)
-    handle_exceptions(__method__) do
-      r_path = @path + '/' + r_name
-      @dropbox.upload(r_path, content, mode: 'overwrite')
-    end
-  end
-
-  def delete_file(r_name)
-    handle_exceptions(__method__) do
-      begin
-        r_path = @path + '/' + r_name
-        @dropbox.delete(r_path)
-        @logger.info("Dropbox file deleted: #{r_path}")
-        true
-      rescue DropboxApi::Errors::NotFoundError
-        false
+    def create_project_folder
+      handle_exceptions(__method__) do
+        @path = '/' + @tag + '-' + @timestamp
+        @dropbox.create_folder(@path)
+        @dropbox.share_folder(@path)
+        @url = @dropbox.create_shared_link_with_settings(@path).url + '&lst='
+        @logger.info("Dropbox project folder created: #{@url}")
       end
     end
-  end
 
-  def close; end
+    def upload_file(l_path, r_name)
+      handle_exceptions(__method__) do
+        content = IO.read(l_path)
+        r_path = @path + '/' + r_name
+        @dropbox.upload(r_path, content)
+      end
+    end
+
+    def update_file_content(content, r_name)
+      handle_exceptions(__method__) do
+        r_path = @path + '/' + r_name
+        @dropbox.upload(r_path, content, mode: 'overwrite')
+      end
+    end
+
+    def delete_file(r_name)
+      handle_exceptions(__method__) do
+        begin
+          r_path = @path + '/' + r_name
+          @dropbox.delete(r_path)
+          @logger.info("Dropbox file deleted: #{r_path}")
+          true
+        rescue DropboxApi::Errors::NotFoundError
+          false
+        end
+      end
+    end
+
+    def close; end
+  end
 end

--- a/lib/resultuploaders/dropbox.rb
+++ b/lib/resultuploaders/dropbox.rb
@@ -7,6 +7,7 @@ module AutoHCK
   # dropbox class
   class Dropbox
     attr_reader :url
+
     def initialize(project)
       @tag = project.tag
       @timestamp = project.timestamp

--- a/lib/resultuploaders/result_uploader.rb
+++ b/lib/resultuploaders/result_uploader.rb
@@ -2,77 +2,80 @@
 
 require './lib/resultuploaders/dropbox'
 
-# ResultUploader
-#
-class ResultUploader
-  # UploaderFactory
+# AutoHCK module
+module AutoHCK
+  # ResultUploader
   #
-  class UploaderFactory
-    UPLOADERS = {
-      dropbox: Dropbox
-    }.freeze
+  class ResultUploader
+    # UploaderFactory
+    #
+    class UploaderFactory
+      UPLOADERS = {
+        dropbox: Dropbox
+      }.freeze
 
-    def self.create(type, project)
-      UPLOADERS[type].new(project)
-    end
+      def self.create(type, project)
+        UPLOADERS[type].new(project)
+      end
 
-    def self.can_create?(type)
-      !UPLOADERS[type].nil?
-    end
-  end
-
-  def initialize(project)
-    @project = project
-    @connected_uploaders = {}
-    @uploaders = {}
-    @project.config['result_uploaders'].uniq.collect(&:to_sym).each do |type|
-      if UploaderFactory.can_create?(type)
-        @uploaders[type] = UploaderFactory.create(type, @project)
-      else
-        @project.logger.info("Unknown type uploader #{type}, (ignoring)")
+      def self.can_create?(type)
+        !UPLOADERS[type].nil?
       end
     end
-  end
 
-  def connect
-    @uploaders.each_pair do |type, uploader|
-      if uploader.connect
-        @connected_uploaders[type] = uploader
-      else
-        @project.logger.info("#{type} connection failed, (ignoring)")
+    def initialize(project)
+      @project = project
+      @connected_uploaders = {}
+      @uploaders = {}
+      @project.config['result_uploaders'].uniq.collect(&:to_sym).each do |type|
+        if UploaderFactory.can_create?(type)
+          @uploaders[type] = UploaderFactory.create(type, @project)
+        else
+          @project.logger.info("Unknown type uploader #{type}, (ignoring)")
+        end
       end
     end
-  end
 
-  def create_project_folder
-    @connected_uploaders.each_value(&:create_project_folder)
-  end
-
-  def delete_file(r_name)
-    @connected_uploaders.each_value do |uploader|
-      uploader.delete_file(r_name)
+    def connect
+      @uploaders.each_pair do |type, uploader|
+        if uploader.connect
+          @connected_uploaders[type] = uploader
+        else
+          @project.logger.info("#{type} connection failed, (ignoring)")
+        end
+      end
     end
-  end
 
-  def upload_file(l_path, r_name)
-    @connected_uploaders.each_value do |uploader|
-      uploader.upload_file(l_path, r_name)
+    def create_project_folder
+      @connected_uploaders.each_value(&:create_project_folder)
     end
-  end
 
-  def update_file_content(content, r_name)
-    @connected_uploaders.each_value do |uploader|
-      uploader.update_file_content(content, r_name)
+    def delete_file(r_name)
+      @connected_uploaders.each_value do |uploader|
+        uploader.delete_file(r_name)
+      end
     end
-  end
 
-  def url
-    return nil unless @connected_uploaders.key?(:dropbox)
+    def upload_file(l_path, r_name)
+      @connected_uploaders.each_value do |uploader|
+        uploader.upload_file(l_path, r_name)
+      end
+    end
 
-    @connected_uploaders[:dropbox].url
-  end
+    def update_file_content(content, r_name)
+      @connected_uploaders.each_value do |uploader|
+        uploader.update_file_content(content, r_name)
+      end
+    end
 
-  def close
-    @connected_uploaders.each_value(&:close)
+    def url
+      return nil unless @connected_uploaders.key?(:dropbox)
+
+      @connected_uploaders[:dropbox].url
+    end
+
+    def close
+      @connected_uploaders.each_value(&:close)
+    end
   end
 end

--- a/lib/setupmanagers/exceptions.rb
+++ b/lib/setupmanagers/exceptions.rb
@@ -12,10 +12,13 @@ module AutoHCK
 
   # custom machine error
   class MachineError < AutoHCKError; end
+
   class MachinePidNil < MachineError; end
+
   class MachineRunError < MachineError; end
 
   # custom client error
   class ClientError < MachineError; end
+
   class ClientRunError < ClientError; end
 end

--- a/lib/setupmanagers/exceptions.rb
+++ b/lib/setupmanagers/exceptions.rb
@@ -2,17 +2,20 @@
 
 require './lib/exceptions'
 
-# A custom SetupManager error exception
-class SetupManagerError < AutoHCKError; end
+# AutoHCK module
+module AutoHCK
+  # A custom SetupManager error exception
+  class SetupManagerError < AutoHCKError; end
 
-# A custom StudioConnect error exception
-class StudioConnectError < AutoHCKError; end
+  # A custom StudioConnect error exception
+  class StudioConnectError < AutoHCKError; end
 
-# custom machine error
-class MachineError < AutoHCKError; end
-class MachinePidNil < MachineError; end
-class MachineRunError < MachineError; end
+  # custom machine error
+  class MachineError < AutoHCKError; end
+  class MachinePidNil < MachineError; end
+  class MachineRunError < MachineError; end
 
-# custom client error
-class ClientError < MachineError; end
-class ClientRunError < ClientError; end
+  # custom client error
+  class ClientError < MachineError; end
+  class ClientRunError < ClientError; end
+end

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -4,176 +4,179 @@ require './lib/setupmanagers/exceptions'
 require './lib/engines/hcktest/tests'
 require './lib/engines/hcktest/targets'
 
-# HCKClient class
-class HCKClient < Machine
-  attr_reader :name, :id, :kit
-  attr_writer :support
-  def initialize(project, setupmanager, studio, tag, name)
-    @id = tag[-1]
-    super(project, name, setupmanager, @id, tag)
-    @studio = studio
-    @kit = setupmanager.kit
-    @pool = 'Default Pool'
-  end
-
-  def create_snapshot
-    @setupmanager.create_client_snapshot(@tag)
-  end
-
-  def delete_snapshot
-    @setupmanager.delete_client_snapshot(@tag)
-  end
-
-  def run
-    create_snapshot
-    super
-  end
-
-  def add_target_to_project
-    @target = Targets.new(self, @project, @tools, @pool).add_target_to_project
-  end
-
-  def run_tests
-    @tests = Tests.new(self, @support, @project, @target, @tools)
-    @tests.list_tests
-    @tests.run
-  end
-
-  def create_package
-    @tests.create_project_package
-  end
-
-  def configure_machine
-    move_machine_to_pool
-    set_machine_ready
-    sleep CLIENT_COOLDOWN_SLEEP
-  end
-
-  def reconfigure_machine
-    delete_machine
-    restart_machine
-    return_when_client_up
-    configure_machine
-  end
-
-  def delete_machine
-    @tools.delete_machine(@name, @pool)
-    @pool = 'Default Pool'
-  end
-
-  def restart_machine
-    @logger.info("Restarting #{@name}")
-    @tools.restart_machine(@name)
-  end
-
-  def move_machine_to_pool
-    @logger.info("Moving #{@name} to pool")
-    @tools.move_machine(@name, @pool, @project.tag)
-    @pool = @project.tag
-  end
-
-  def set_machine_ready
-    @logger.info("Setting #{@name} state to Ready")
-    return if @tools.set_machine_ready(@name, @pool)
-
-    raise ClientRunError, "Couldn't set #{@name} state to Ready"
-  end
-
-  def run_pre_test_commands
-    @project.driver['pretestcommands']&.each do |command|
-      desc = command['desc']
-      cmd = command['run']
-
-      @logger.info("Running command (#{desc}) on client #{@name}")
-      @tools.run_on_machine(@name, desc, cmd)
+# AutoHCK module
+module AutoHCK
+  # HCKClient class
+  class HCKClient < Machine
+    attr_reader :name, :id, :kit
+    attr_writer :support
+    def initialize(project, setupmanager, studio, tag, name)
+      @id = tag[-1]
+      super(project, name, setupmanager, @id, tag)
+      @studio = studio
+      @kit = setupmanager.kit
+      @pool = 'Default Pool'
     end
-  end
 
-  def install_driver
-    method = @project.driver['install_method']
-    path = @project.driver_path
-    inf = @project.driver['inf']
-    @logger.info("Installing #{method} driver #{inf} in #{@name}")
-    @tools.install_machine_driver_package(@name, path, method, inf)
-  end
+    def create_snapshot
+      @setupmanager.create_client_snapshot(@tag)
+    end
 
-  def machine_in_default_pool
-    default_pool = @studio.list_pools
-                          .detect { |pool| pool['name'].eql?('Default Pool') }
+    def delete_snapshot
+      @setupmanager.delete_client_snapshot(@tag)
+    end
 
-    default_pool['machines'].detect { |machine| machine['name'].eql?(@name) }
-  end
+    def run
+      create_snapshot
+      super
+    end
 
-  def recognize_client_wait
-    @logger.info("Waiting for client #{@name} to be recognized")
-    sleep 5 until machine_in_default_pool
-    @logger.info("Client #{@name} recognized")
-  end
+    def add_target_to_project
+      @target = Targets.new(self, @project, @tools, @pool).add_target_to_project
+    end
 
-  def initialize_client_wait
-    @logger.info("Waiting for client #{@name} initialization")
-    sleep 5 while machine_in_default_pool['state'].eql?('Initializing')
-    @logger.info("Client #{@name} initialized")
-  end
+    def run_tests
+      @tests = Tests.new(self, @support, @project, @target, @tools)
+      @tests.list_tests
+      @tests.run
+    end
 
-  def return_when_client_up
-    recognize_client_wait
-    initialize_client_wait
-  end
+    def create_package
+      @tests.create_project_package
+    end
 
-  # Client cooldown timeout in seconds, to prevent hangs (30 minutes)
-  CLIENT_COOLDOWN_TIMEOUT = 1800
+    def configure_machine
+      move_machine_to_pool
+      set_machine_ready
+      sleep CLIENT_COOLDOWN_SLEEP
+    end
 
-  # Client cooldown sleep after thread is joined in seconds
-  CLIENT_COOLDOWN_SLEEP = 60
-
-  def configure
-    @tools = @studio.tools
-    @cooldown_thread = Thread.new do
+    def reconfigure_machine
+      delete_machine
+      restart_machine
       return_when_client_up
-      install_driver
-      @logger.info("Configuring client #{@name}...")
       configure_machine
-      run_pre_test_commands
-      add_target_to_project
     end
-  end
 
-  def synchronize(exit: false)
-    if exit
-      @cooldown_thread&.exit
-    else
-      return unless @cooldown_thread&.join(CLIENT_COOLDOWN_TIMEOUT).nil?
-
-      e_message = "Timeout expired for the cooldown thread of client #{@name}"
-      raise ClientRunError, e_message
+    def delete_machine
+      @tools.delete_machine(@name, @pool)
+      @pool = 'Default Pool'
     end
-  end
 
-  def not_ready?
-    @studio.list_pools.detect { |pool| pool['name'].eql?(@pool) }['machines']\
-           .detect { |machine| machine['name'].eql?(@name) }['state']\
-           .eql?('NotReady')
-  end
+    def restart_machine
+      @logger.info("Restarting #{@name}")
+      @tools.restart_machine(@name)
+    end
 
-  def reset_to_ready_state
-    return unless not_ready?
+    def move_machine_to_pool
+      @logger.info("Moving #{@name} to pool")
+      @tools.move_machine(@name, @pool, @project.tag)
+      @pool = @project.tag
+    end
 
-    @logger.info("Setting client #{@name} state to Ready")
-    set_machine_ready
-  end
+    def set_machine_ready
+      @logger.info("Setting #{@name} state to Ready")
+      return if @tools.set_machine_ready(@name, @pool)
 
-  def keep_alive
-    return if alive?
+      raise ClientRunError, "Couldn't set #{@name} state to Ready"
+    end
 
-    @logger.info("Starting client #{@name}")
-    @pid = @setupmanager.run(@tag)
-    e_message = "Client #{@name} new PID could not be retrieved"
-    raise ClientRunError, e_message unless @pid
+    def run_pre_test_commands
+      @project.driver['pretestcommands']&.each do |command|
+        desc = command['desc']
+        cmd = command['run']
 
-    @logger.info("Client #{@name} new PID is #{@pid}")
-    raise ClientRunError, "Could not start client #{@name}" unless alive?
-  rescue CmdRunError
-    raise ClientRunError, "Could not start client #{@name}"
+        @logger.info("Running command (#{desc}) on client #{@name}")
+        @tools.run_on_machine(@name, desc, cmd)
+      end
+    end
+
+    def install_driver
+      method = @project.driver['install_method']
+      path = @project.driver_path
+      inf = @project.driver['inf']
+      @logger.info("Installing #{method} driver #{inf} in #{@name}")
+      @tools.install_machine_driver_package(@name, path, method, inf)
+    end
+
+    def machine_in_default_pool
+      default_pool = @studio.list_pools
+                            .detect { |pool| pool['name'].eql?('Default Pool') }
+
+      default_pool['machines'].detect { |machine| machine['name'].eql?(@name) }
+    end
+
+    def recognize_client_wait
+      @logger.info("Waiting for client #{@name} to be recognized")
+      sleep 5 until machine_in_default_pool
+      @logger.info("Client #{@name} recognized")
+    end
+
+    def initialize_client_wait
+      @logger.info("Waiting for client #{@name} initialization")
+      sleep 5 while machine_in_default_pool['state'].eql?('Initializing')
+      @logger.info("Client #{@name} initialized")
+    end
+
+    def return_when_client_up
+      recognize_client_wait
+      initialize_client_wait
+    end
+
+    # Client cooldown timeout in seconds, to prevent hangs (30 minutes)
+    CLIENT_COOLDOWN_TIMEOUT = 1800
+
+    # Client cooldown sleep after thread is joined in seconds
+    CLIENT_COOLDOWN_SLEEP = 60
+
+    def configure
+      @tools = @studio.tools
+      @cooldown_thread = Thread.new do
+        return_when_client_up
+        install_driver
+        @logger.info("Configuring client #{@name}...")
+        configure_machine
+        run_pre_test_commands
+        add_target_to_project
+      end
+    end
+
+    def synchronize(exit: false)
+      if exit
+        @cooldown_thread&.exit
+      else
+        return unless @cooldown_thread&.join(CLIENT_COOLDOWN_TIMEOUT).nil?
+
+        e_message = "Timeout expired for the cooldown thread of client #{@name}"
+        raise ClientRunError, e_message
+      end
+    end
+
+    def not_ready?
+      @studio.list_pools.detect { |pool| pool['name'].eql?(@pool) }['machines']\
+             .detect { |machine| machine['name'].eql?(@name) }['state']\
+             .eql?('NotReady')
+    end
+
+    def reset_to_ready_state
+      return unless not_ready?
+
+      @logger.info("Setting client #{@name} state to Ready")
+      set_machine_ready
+    end
+
+    def keep_alive
+      return if alive?
+
+      @logger.info("Starting client #{@name}")
+      @pid = @setupmanager.run(@tag)
+      e_message = "Client #{@name} new PID could not be retrieved"
+      raise ClientRunError, e_message unless @pid
+
+      @logger.info("Client #{@name} new PID is #{@pid}")
+      raise ClientRunError, "Could not start client #{@name}" unless alive?
+    rescue CmdRunError
+      raise ClientRunError, "Could not start client #{@name}"
+    end
   end
 end

--- a/lib/setupmanagers/hckclient.rb
+++ b/lib/setupmanagers/hckclient.rb
@@ -10,6 +10,7 @@ module AutoHCK
   class HCKClient < Machine
     attr_reader :name, :id, :kit
     attr_writer :support
+
     def initialize(project, setupmanager, studio, tag, name)
       @id = tag[-1]
       super(project, name, setupmanager, @id, tag)

--- a/lib/setupmanagers/hckstudio.rb
+++ b/lib/setupmanagers/hckstudio.rb
@@ -9,6 +9,7 @@ module AutoHCK
   # HCKStudio class
   class HCKStudio < Machine
     attr_reader :tools, :name, :id, :setupmanager
+
     HCK_FILTERS_PATH = 'filters/UpdateFilters.sql'
     def initialize(project, setupmanager, name, ip)
       super(project, name, setupmanager, 0, 'st')

--- a/lib/setupmanagers/hckstudio.rb
+++ b/lib/setupmanagers/hckstudio.rb
@@ -4,124 +4,127 @@ require 'net/ping'
 require './lib/setupmanagers/machine'
 require './lib/engines/hcktest/tools'
 
-# HCKStudio class
-class HCKStudio < Machine
-  attr_reader :tools, :name, :id, :setupmanager
-  HCK_FILTERS_PATH = 'filters/UpdateFilters.sql'
-  def initialize(project, setupmanager, name, ip)
-    super(project, name, setupmanager, 0, 'st')
-    @ip = ip
-  end
-
-  def up?
-    check = Net::Ping::External.new(@ip)
-    check.ping?
-  end
-
-  def create_snapshot
-    @setupmanager.create_studio_snapshot
-  end
-
-  def delete_snapshot
-    @setupmanager.delete_studio_snapshot
-  end
-
-  def create_pool
-    @logger.info('Creating pool')
-    tag = @project.tag
-    @tools.create_pool(tag)
-  end
-
-  def delete_pool
-    @logger.info('Deleting pool')
-    tag = @project.tag
-    @tools.delete_pool(tag)
-  end
-
-  def create_project
-    @logger.info('Creating project')
-    tag = @project.tag
-    @tools.create_project(tag)
-  end
-
-  def delete_project
-    @logger.info('Deleting project')
-    tag = @project.tag
-    @tools.delete_project(tag)
-  end
-
-  def list_pools
-    @tools.list_pools
-  end
-
-  def update_filters
-    return unless File.file?(HCK_FILTERS_PATH)
-
-    @logger.info('Updating HCK filters')
-    @tools.update_filters(HCK_FILTERS_PATH)
-  end
-
-  CONNECT_RETRIES = 5
-  CONNECT_RETRY_SLEEP = 10
-
-  def connect
-    retries ||= 0
-    begin
-      @logger.info('Initiating connection to studio')
-      @tools = Tools.new(@project, @ip, @clients)
-    rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, RToolsHCKConnectionError
-      raise StudioConnectError, 'Initiating connection to studio failed'
+# AutoHCK module
+module AutoHCK
+  # HCKStudio class
+  class HCKStudio < Machine
+    attr_reader :tools, :name, :id, :setupmanager
+    HCK_FILTERS_PATH = 'filters/UpdateFilters.sql'
+    def initialize(project, setupmanager, name, ip)
+      super(project, name, setupmanager, 0, 'st')
+      @ip = ip
     end
-  rescue StudioConnectError => e
-    @logger.warn(e.message)
-    raise unless (retries + 1) < CONNECT_RETRIES
 
-    sleep CONNECT_RETRY_SLEEP
-    @logger.info('Trying again to initiate connection to studio')
-    retry
-  end
+    def up?
+      check = Net::Ping::External.new(@ip)
+      check.ping?
+    end
 
-  def verify_tools
-    return if @tools.connection_check
+    def create_snapshot
+      @setupmanager.create_studio_snapshot
+    end
 
-    raise StudioConnectError, 'Tools did not pass the connection check'
-  end
+    def delete_snapshot
+      @setupmanager.delete_studio_snapshot
+    end
 
-  def run
-    create_snapshot
-    super
-  end
+    def create_pool
+      @logger.info('Creating pool')
+      tag = @project.tag
+      @tools.create_pool(tag)
+    end
 
-  def clean_tools
-    delete_project
-    delete_pool
-    @tools&.close
-    @tools = nil
-  end
+    def delete_pool
+      @logger.info('Deleting pool')
+      tag = @project.tag
+      @tools.delete_pool(tag)
+    end
 
-  def clean_last_run
-    clean_tools unless @tools.nil?
-    super
-  end
+    def create_project
+      @logger.info('Creating project')
+      tag = @project.tag
+      @tools.create_project(tag)
+    end
 
-  def configure(clients)
-    @clients = clients
-    @logger.info('Waiting for studio to load...')
-    sleep 5 until up?
-    connect
-    verify_tools
-    update_filters
-    create_pool
-    create_project
-  end
+    def delete_project
+      @logger.info('Deleting project')
+      tag = @project.tag
+      @tools.delete_project(tag)
+    end
 
-  def abort
-    @tools&.close unless @tools.nil?
-    super
-  end
+    def list_pools
+      @tools.list_pools
+    end
 
-  def shutdown
-    @logger.info('Shutting down studio')
-    @tools.shutdown
+    def update_filters
+      return unless File.file?(HCK_FILTERS_PATH)
+
+      @logger.info('Updating HCK filters')
+      @tools.update_filters(HCK_FILTERS_PATH)
+    end
+
+    CONNECT_RETRIES = 5
+    CONNECT_RETRY_SLEEP = 10
+
+    def connect
+      retries ||= 0
+      begin
+        @logger.info('Initiating connection to studio')
+        @tools = Tools.new(@project, @ip, @clients)
+      rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, RToolsHCKConnectionError
+        raise StudioConnectError, 'Initiating connection to studio failed'
+      end
+    rescue StudioConnectError => e
+      @logger.warn(e.message)
+      raise unless (retries + 1) < CONNECT_RETRIES
+
+      sleep CONNECT_RETRY_SLEEP
+      @logger.info('Trying again to initiate connection to studio')
+      retry
+    end
+
+    def verify_tools
+      return if @tools.connection_check
+
+      raise StudioConnectError, 'Tools did not pass the connection check'
+    end
+
+    def run
+      create_snapshot
+      super
+    end
+
+    def clean_tools
+      delete_project
+      delete_pool
+      @tools&.close
+      @tools = nil
+    end
+
+    def clean_last_run
+      clean_tools unless @tools.nil?
+      super
+    end
+
+    def configure(clients)
+      @clients = clients
+      @logger.info('Waiting for studio to load...')
+      sleep 5 until up?
+      connect
+      verify_tools
+      update_filters
+      create_pool
+      create_project
+    end
+
+    def abort
+      @tools&.close unless @tools.nil?
+      super
+    end
+
+    def shutdown
+      @logger.info('Shutting down studio')
+      @tools.shutdown
+    end
   end
 end

--- a/lib/setupmanagers/machine.rb
+++ b/lib/setupmanagers/machine.rb
@@ -9,6 +9,7 @@ module AutoHCK
   # Machine class
   class Machine
     attr_reader :name
+
     def initialize(project, name, setupmanager, id, tag)
       @name = name
       @tag = tag

--- a/lib/setupmanagers/machine.rb
+++ b/lib/setupmanagers/machine.rb
@@ -4,91 +4,94 @@ require './lib/setupmanagers/setupmanager'
 require './lib/setupmanagers/exceptions'
 require './lib/setupmanagers/monitor'
 
-# Machine class
-class Machine
-  attr_reader :name
-  def initialize(project, name, setupmanager, id, tag)
-    @name = name
-    @tag = tag
-    @project = project
-    @setupmanager = setupmanager
-    @logger = project.logger
-    @id = id
-  end
+# AutoHCK module
+module AutoHCK
+  # Machine class
+  class Machine
+    attr_reader :name
+    def initialize(project, name, setupmanager, id, tag)
+      @name = name
+      @tag = tag
+      @project = project
+      @setupmanager = setupmanager
+      @logger = project.logger
+      @id = id
+    end
 
-  def run
-    @logger.info("Starting #{@name}")
-    @pid = @setupmanager.run(@tag, true)
-    raise MachinePidNil, "#{@name} PID could not be retrieved" unless @pid
+    def run
+      @logger.info("Starting #{@name}")
+      @pid = @setupmanager.run(@tag, true)
+      raise MachinePidNil, "#{@name} PID could not be retrieved" unless @pid
 
-    return if @pid.negative?
+      return if @pid.negative?
 
-    @logger.info("#{@name} PID is #{@pid}")
-    @monitor = Monitor.new(@project, self)
-    raise MachineRunError, "Could not start #{@name}" unless alive?
-  rescue CmdRunError
-    raise MachineRunError, "Could not start #{@name}"
-  end
+      @logger.info("#{@name} PID is #{@pid}")
+      @monitor = Monitor.new(@project, self)
+      raise MachineRunError, "Could not start #{@name}" unless alive?
+    rescue CmdRunError
+      raise MachineRunError, "Could not start #{@name}"
+    end
 
-  def hard_abort
-    @monitor&.quit
-    sleep ABORT_SLEEP
-    return true unless alive?
+    def hard_abort
+      @monitor&.quit
+      sleep ABORT_SLEEP
+      return true unless alive?
 
-    false
-  end
+      false
+    end
 
-  def clean_last_run
-    return if @pid.negative?
+    def clean_last_run
+      return if @pid.negative?
 
-    @logger.info("Cleaning last #{@name} run")
-    unless hard_abort
+      @logger.info("Cleaning last #{@name} run")
+      unless hard_abort
+        @logger.info("#{@name} hard abort failed, force aborting...")
+        Process.kill('KILL', @pid)
+      end
+      delete_snapshot
+    end
+
+    def powerdown
+      return if @pid.negative?
+
+      @monitor&.powerdown
+    end
+
+    # machine soft abort trials before force abort
+    ABORT_RETRIES = 3
+
+    # machine soft abort sleep for each trial
+    ABORT_SLEEP = 5
+
+    def soft_abort
+      ABORT_RETRIES.times do
+        return true unless alive?
+
+        powerdown
+        sleep ABORT_SLEEP
+      end
+      false
+    end
+
+    def abort
+      return if @pid.negative? || soft_abort
+
+      @logger.info("#{@name} soft abort failed, hard aborting...")
+      return if hard_abort
+
       @logger.info("#{@name} hard abort failed, force aborting...")
       Process.kill('KILL', @pid)
     end
-    delete_snapshot
-  end
 
-  def powerdown
-    return if @pid.negative?
+    def alive?
+      return false if @pid.nil?
+      return true if @pid&.negative?
 
-    @monitor&.powerdown
-  end
-
-  # machine soft abort trials before force abort
-  ABORT_RETRIES = 3
-
-  # machine soft abort sleep for each trial
-  ABORT_SLEEP = 5
-
-  def soft_abort
-    ABORT_RETRIES.times do
-      return true unless alive?
-
-      powerdown
-      sleep ABORT_SLEEP
+      Process.kill(0, @pid)
+      true
+    rescue Errno::ESRCH
+      @logger.info("#{@name} is not alive")
+      false
     end
-    false
-  end
-
-  def abort
-    return if @pid.negative? || soft_abort
-
-    @logger.info("#{@name} soft abort failed, hard aborting...")
-    return if hard_abort
-
-    @logger.info("#{@name} hard abort failed, force aborting...")
-    Process.kill('KILL', @pid)
-  end
-
-  def alive?
-    return false if @pid.nil?
-    return true if @pid&.negative?
-
-    Process.kill(0, @pid)
-    true
-  rescue Errno::ESRCH
-    @logger.info("#{@name} is not alive")
-    false
   end
 end

--- a/lib/setupmanagers/monitor.rb
+++ b/lib/setupmanagers/monitor.rb
@@ -2,45 +2,48 @@
 
 require 'net-telnet'
 
-# monitor class
-class Monitor
-  MONITOR_BASE_PORT = 10_000
-  TIMEOUT = 30
-  LOCALHOST = 'localhost'
+# AutoHCK module
+module AutoHCK
+  # monitor class
+  class Monitor
+    MONITOR_BASE_PORT = 10_000
+    TIMEOUT = 30
+    LOCALHOST = 'localhost'
 
-  def initialize(project, machine)
-    @name = machine.name
-    @id = machine.id
-    @project_id = project.id
-    client_id = 3 * @project_id.to_i - 2 + @id.to_i
-    @port = MONITOR_BASE_PORT + client_id
-    @logger = project.logger
-    @logger.info('Initiating qemu-monitor session')
-  end
+    def initialize(project, machine)
+      @name = machine.name
+      @id = machine.id
+      @project_id = project.id
+      client_id = 3 * @project_id.to_i - 2 + @id.to_i
+      @port = MONITOR_BASE_PORT + client_id
+      @logger = project.logger
+      @logger.info('Initiating qemu-monitor session')
+    end
 
-  def quit
-    @logger.info("Sending quit signal to #{@name} via qemu-monitor")
-    cmd('quit')
-  end
+    def quit
+      @logger.info("Sending quit signal to #{@name} via qemu-monitor")
+      cmd('quit')
+    end
 
-  def powerdown
-    @logger.info("Sending powerdown signal to #{@name} via qemu-monitor")
-    cmd('system_powerdown')
-  end
+    def powerdown
+      @logger.info("Sending powerdown signal to #{@name} via qemu-monitor")
+      cmd('system_powerdown')
+    end
 
-  def reset
-    @logger.info("Sending reset signal to #{@name} via qemu-monitor")
-    cmd('system_reset')
-  end
+    def reset
+      @logger.info("Sending reset signal to #{@name} via qemu-monitor")
+      cmd('system_reset')
+    end
 
-  def cmd(cmd)
-    monitor = Net::Telnet.new('Host' => LOCALHOST,
-                              'Port' => @port,
-                              'Timeout' => TIMEOUT,
-                              'Prompt' => /\(qemu\)/)
-    monitor.cmd(cmd)
-    monitor.close
-  rescue Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED
-    @logger.warn("#{@name} qemu-monitor not responding")
+    def cmd(cmd)
+      monitor = Net::Telnet.new('Host' => LOCALHOST,
+                                'Port' => @port,
+                                'Timeout' => TIMEOUT,
+                                'Prompt' => /\(qemu\)/)
+      monitor.cmd(cmd)
+      monitor.close
+    rescue Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED
+      @logger.warn("#{@name} qemu-monitor not responding")
+    end
   end
 end

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -10,6 +10,7 @@ module AutoHCK
     include Helper
 
     attr_reader :kit
+
     PHYSHCK_CONFIG_JSON = 'lib/setupmanagers/physhck/physhck.json'
     PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
 

--- a/lib/setupmanagers/physhck/physhck.rb
+++ b/lib/setupmanagers/physhck/physhck.rb
@@ -3,67 +3,72 @@
 require './lib/exceptions'
 require './lib/auxiliary/json_helper'
 
-# PhysHCK
-class PhysHCK
-  attr_reader :kit
-  PHYSHCK_CONFIG_JSON = 'lib/setupmanagers/physhck/physhck.json'
-  PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
+# AutoHCK module
+module AutoHCK
+  # PhysHCK
+  class PhysHCK
+    include Helper
 
-  def initialize(project)
-    @project = project
-    @logger = project.logger
-    @platform = read_platform
-    @setup = find_setup
-    @id = project.id
-    @kit = @setup['kit']
-  end
+    attr_reader :kit
+    PHYSHCK_CONFIG_JSON = 'lib/setupmanagers/physhck/physhck.json'
+    PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
 
-  def find_setup
-    known_setups = read_json(PHYSHCK_CONFIG_JSON, @logger)
-    res = known_setups.find { |setup| setup['name'] == @platform['name'] }
-    @project.logger.fatal("#{@platform['name']} does not exist") unless res
-    res || raise(SetupManagerError, "#{@platform['name']} does not exist")
-  end
+    def initialize(project)
+      @project = project
+      @logger = project.logger
+      @platform = read_platform
+      @setup = find_setup
+      @id = project.id
+      @kit = @setup['kit']
+    end
 
-  def read_platform
-    platforms = read_json(PLATFORMS_JSON, @project.logger)
-    platform_name = @project.tag.split('-', 2).last
-    res = platforms.find { |p| p['name'] == platform_name }
-    @project.logger.fatal("#{platform_name} does not exist") unless res
-    res || raise(SetupManagerError, "#{platform_name} does not exist")
-  end
+    def find_setup
+      known_setups = read_json(PHYSHCK_CONFIG_JSON, @logger)
+      res = known_setups.find { |setup| setup['name'] == @platform['name'] }
+      @project.logger.fatal("#{@platform['name']} does not exist") unless res
+      res || raise(SetupManagerError, "#{@platform['name']} does not exist")
+    end
 
-  def create_studio_snapshot
-    @logger.info('Snapshots are currently not supported for physical machines')
-  end
+    def read_platform
+      platforms = read_json(PLATFORMS_JSON, @project.logger)
+      platform_name = @project.tag.split('-', 2).last
+      res = platforms.find { |p| p['name'] == platform_name }
+      @project.logger.fatal("#{platform_name} does not exist") unless res
+      res || raise(SetupManagerError, "#{platform_name} does not exist")
+    end
 
-  def delete_studio_snapshot
-    @logger.info('Snapshots are currently not supported for physical machines')
-  end
+    def create_studio_snapshot
+      @logger.info('Snapshots are currently not supported for physical machines')
+    end
 
-  def create_client_snapshot(_name)
-    @logger.info('Snapshots are currently not supported for physical machines')
-  end
+    def delete_studio_snapshot
+      @logger.info('Snapshots are currently not supported for physical machines')
+    end
 
-  def delete_client_snapshot(_name)
-    @logger.info('Snapshots are currently not supported for physical machines')
-  end
+    def create_client_snapshot(_name)
+      @logger.info('Snapshots are currently not supported for physical machines')
+    end
 
-  def run(*)
-    # Physical = no pid
-    -1
-  end
+    def delete_client_snapshot(_name)
+      @logger.info('Snapshots are currently not supported for physical machines')
+    end
 
-  def create_studio
-    studio_ip = @setup['st_ip']
-    @studio = HCKStudio.new(@project, self, 'st', studio_ip)
-  end
+    def run(*)
+      # Physical = no pid
+      -1
+    end
 
-  def create_client(tag, name)
-    HCKClient.new(@project, self, @studio, tag, name)
-  end
+    def create_studio
+      studio_ip = @setup['st_ip']
+      @studio = HCKStudio.new(@project, self, 'st', studio_ip)
+    end
 
-  def close
-    @logger.info('Closing setup manager')
+    def create_client(tag, name)
+      HCKClient.new(@project, self, @studio, tag, name)
+    end
+
+    def close
+      @logger.info('Closing setup manager')
+    end
   end
 end

--- a/lib/setupmanagers/setupmanager.rb
+++ b/lib/setupmanagers/setupmanager.rb
@@ -10,6 +10,7 @@ module AutoHCK
   #
   class SetupManager
     attr_reader :id
+
     # SetupManagerFactory
     #
     class SetupManagerFactory

--- a/lib/setupmanagers/setupmanager.rb
+++ b/lib/setupmanagers/setupmanager.rb
@@ -4,72 +4,75 @@ require './lib/exceptions'
 require './lib/setupmanagers/virthck/virthck'
 require './lib/setupmanagers/physhck/physhck'
 
-# SetupManager
-#
-class SetupManager
-  attr_reader :id
-  # SetupManagerFactory
+# AutoHCK module
+module AutoHCK
+  # SetupManager
   #
-  class SetupManagerFactory
-    SETUP_MANAGERS = {
-      virthck: VirtHCK,
-      physhck: PhysHCK
-    }.freeze
+  class SetupManager
+    attr_reader :id
+    # SetupManagerFactory
+    #
+    class SetupManagerFactory
+      SETUP_MANAGERS = {
+        virthck: VirtHCK,
+        physhck: PhysHCK
+      }.freeze
 
-    def self.create(type, project)
-      SETUP_MANAGERS[type].new(project)
+      def self.create(type, project)
+        SETUP_MANAGERS[type].new(project)
+      end
+
+      def self.can_create?(type)
+        !SETUP_MANAGERS[type].nil?
+      end
     end
 
-    def self.can_create?(type)
-      !SETUP_MANAGERS[type].nil?
+    def initialize(project)
+      @project = project
+      @logger = project.logger
+      @type = project.setupmanager.downcase.to_sym
+      setupmanager_create
     end
-  end
 
-  def initialize(project)
-    @project = project
-    @logger = project.logger
-    @type = project.setupmanager.downcase.to_sym
-    setupmanager_create
-  end
-
-  def setupmanager_create
-    if SetupManagerFactory.can_create?(@type)
-      @setupmanager = SetupManagerFactory.create(@type, @project)
-    else
-      @logger.warn("Unkown type setup mainager #{@type}, Exiting...")
-      raise SetupManagerError, "Unkown type setup manager #{@type}"
+    def setupmanager_create
+      if SetupManagerFactory.can_create?(@type)
+        @setupmanager = SetupManagerFactory.create(@type, @project)
+      else
+        @logger.warn("Unkown type setup mainager #{@type}, Exiting...")
+        raise SetupManagerError, "Unkown type setup manager #{@type}"
+      end
     end
-  end
 
-  def create_studio_snapshot
-    @setupmanager.create_studio_snapshot
-  end
+    def create_studio_snapshot
+      @setupmanager.create_studio_snapshot
+    end
 
-  def delete_studio_snapshot
-    @setupmanager.delete_studio_snapshot
-  end
+    def delete_studio_snapshot
+      @setupmanager.delete_studio_snapshot
+    end
 
-  def create_client_snapshot(name)
-    @setupmanager.create_client_snapshot(name)
-  end
+    def create_client_snapshot(name)
+      @setupmanager.create_client_snapshot(name)
+    end
 
-  def delete_client_snapshot(name)
-    @setupmanager.delete_client_snapshot(name)
-  end
+    def delete_client_snapshot(name)
+      @setupmanager.delete_client_snapshot(name)
+    end
 
-  def run(name, first_time = false)
-    @setupmanager.run(name, first_time)
-  end
+    def run(name, first_time = false)
+      @setupmanager.run(name, first_time)
+    end
 
-  def create_studio
-    @setupmanager.create_studio
-  end
+    def create_studio
+      @setupmanager.create_studio
+    end
 
-  def create_client(tag, name)
-    @setupmanager.create_client(tag, name)
-  end
+    def create_client(tag, name)
+      @setupmanager.create_client(tag, name)
+    end
 
-  def close
-    @setupmanager.close
+    def close
+      @setupmanager.close
+    end
   end
 end

--- a/lib/setupmanagers/virthck/virthck.rb
+++ b/lib/setupmanagers/virthck/virthck.rb
@@ -12,6 +12,7 @@ module AutoHCK
     include Helper
 
     attr_reader :kit
+
     VIRTHCK_CONFIG_JSON = 'lib/setupmanagers/virthck/virthck.json'
     PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
     STUDIO = 'st'

--- a/lib/setupmanagers/virthck/virthck.rb
+++ b/lib/setupmanagers/virthck/virthck.rb
@@ -40,12 +40,12 @@ module AutoHCK
 
     def studio_snapshot
       filename = File.basename(@platform['st_image'], '.*')
-      @workspace_path + '/' + filename + '-snapshot.qcow2'
+      "#{@workspace_path}/#{filename}-snapshot.qcow2"
     end
 
     def client_snapshot(name)
       filename = File.basename(@platform['clients'][name]['image'], '.*')
-      @workspace_path + '/' + filename + '-snapshot.qcow2'
+      "#{@workspace_path}/#{filename}-snapshot.qcow2"
     end
 
     def platform_config(param)

--- a/lib/setupmanagers/virthck/virthck.rb
+++ b/lib/setupmanagers/virthck/virthck.rb
@@ -5,186 +5,191 @@ require './lib/exceptions'
 require './lib/auxiliary/json_helper'
 require './lib/auxiliary/host_helper'
 
-# Virthck class
-class VirtHCK
-  attr_reader :kit
-  VIRTHCK_CONFIG_JSON = 'lib/setupmanagers/virthck/virthck.json'
-  PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
-  STUDIO = 'st'
+# AutoHCK module
+module AutoHCK
+  # Virthck class
+  class VirtHCK
+    include Helper
 
-  def initialize(project)
-    @project = project
-    @logger = project.logger
-    @config = read_json(VIRTHCK_CONFIG_JSON, @logger)
-    @device = project.driver['device']
-    @platform = read_platform
-    @workspace_path = project.workspace_path
-    @id = project.id
-    @kit = @platform['kit']
-    validate_paths
-  end
+    attr_reader :kit
+    VIRTHCK_CONFIG_JSON = 'lib/setupmanagers/virthck/virthck.json'
+    PLATFORMS_JSON = 'lib/engines/hcktest/platforms.json'
+    STUDIO = 'st'
 
-  def read_platform
-    platforms = read_json(PLATFORMS_JSON, @project.logger)
-    platform_name = @project.tag.split('-', 2).last
-    @project.logger.info("Loading platform: #{platform_name}")
-    res = platforms.find { |p| p['name'] == platform_name }
-    @project.logger.fatal("#{platform_name} does not exist") unless res
-    res || raise(SetupManagerError, "#{platform_name} does not exist")
-  end
-
-  def studio_snapshot
-    filename = File.basename(@platform['st_image'], '.*')
-    @workspace_path + '/' + filename + '-snapshot.qcow2'
-  end
-
-  def client_snapshot(name)
-    filename = File.basename(@platform['clients'][name]['image'], '.*')
-    @workspace_path + '/' + filename + '-snapshot.qcow2'
-  end
-
-  def platform_config(param)
-    default_value = @config['platforms_defaults'][param]
-    @platform[param] || default_value
-  end
-
-  def base_cmd
-    ["cd #{@config['virthck_path']} &&",
-     "sudo ./hck.sh ci_mode -id #{@id}",
-     "-world_bridge #{@config['dhcp_bridge']}",
-     "-qemu_bin #{@config['qemu_bin']}",
-     "-ivshmem_server_bin #{@config['ivshmem_server_bin']}",
-     "-fs_deamon_bin #{@config['fs_deamon_bin']}",
-     "-filesystem_tests_image #{@config['filesystem_tests_image']}",
-     "-ctrl_net_device #{platform_config('ctrl_net_device')}",
-     "-world_net_device #{platform_config('world_net_device')}",
-     "-viommu #{platform_config('viommu')}",
-     "-st_image #{studio_snapshot}"]
-  end
-
-  def device_cmd
-    ["-device_type #{@device['type']}",
-     !@device['name'].empty? ? "-device_name #{@device['name']}" : '',
-     !@device['extra'].empty? ? "-device_extra #{@device['extra']}" : '',
-     "-machine_type #{platform_config('machine_type')}",
-     "-s3 #{platform_config('s3')}",
-     "-s4 #{platform_config('s4')}",
-     "-enlightenments_state #{platform_config('enlightenments_state')}",
-     "-vhost_state #{platform_config('vhost_state')}"]
-  end
-
-  def client_cmd(name, client)
-    ["-#{name}_image #{client_snapshot(name)}",
-     "-#{name}_memory #{client['memory']}",
-     "-#{name}_cpus #{client['cpus']}"]
-  end
-
-  def clients_cmd
-    clients = []
-    @platform['clients'].each do |name, client|
-      clients += client_cmd(name, client)
+    def initialize(project)
+      @project = project
+      @logger = project.logger
+      @config = read_json(VIRTHCK_CONFIG_JSON, @logger)
+      @device = project.driver['device']
+      @platform = read_platform
+      @workspace_path = project.workspace_path
+      @id = project.id
+      @kit = @platform['kit']
+      validate_paths
     end
-    clients
-  end
 
-  def retrieve_pid(pid_file)
-    Timeout.timeout(5) do
-      sleep 1 while File.zero?(pid_file.path)
+    def read_platform
+      platforms = read_json(PLATFORMS_JSON, @project.logger)
+      platform_name = @project.tag.split('-', 2).last
+      @project.logger.info("Loading platform: #{platform_name}")
+      res = platforms.find { |p| p['name'] == platform_name }
+      @project.logger.fatal("#{platform_name} does not exist") unless res
+      res || raise(SetupManagerError, "#{platform_name} does not exist")
     end
-    pid_file.read.strip.to_i
-  rescue Timeout::Error
-    nil
-  end
 
-  def run(name, first_time = false)
-    sleep(rand(10))
-    temp_file do |pid|
-      cmd = base_cmd + clients_cmd + device_cmd +
-            ["-pidfile #{pid.path}", name]
-      create_command_file(cmd.join(' '), name) if first_time
-      run_cmd(cmd)
-      retrieve_pid(pid)
+    def studio_snapshot
+      filename = File.basename(@platform['st_image'], '.*')
+      @workspace_path + '/' + filename + '-snapshot.qcow2'
     end
-  end
 
-  def close
-    @logger.info('Cleanup host configurations')
-    cmd = base_cmd + device_cmd + ['end']
-    run_cmd(cmd)
-  end
-
-  def create_client_snapshot(name)
-    client = @platform['clients'][name]
-    @logger.info("Creating #{client['name']} snapshot file")
-    base = "#{@config['images_path']}/#{client['image']}"
-    target = client_snapshot(name)
-    create_snapshot_cmd(base, target)
-  end
-
-  def delete_client_snapshot(name)
-    client = @platform['clients'][name]
-    @logger.info("Deleting #{client['name']} snapshot file")
-    target = client_snapshot(name)
-    FileUtils.rm_f(target)
-  end
-
-  def create_studio_snapshot
-    @logger.info('Creating studio snapshot file')
-    base = "#{@config['images_path']}/#{@platform['st_image']}"
-    target = studio_snapshot
-    create_snapshot_cmd(base, target)
-  end
-
-  def delete_studio_snapshot
-    @logger.info('Deleting studio snapshot file')
-    target = studio_snapshot
-    FileUtils.rm_f(target)
-  end
-
-  def create_snapshot_cmd(base, target)
-    cmd = ["#{@config['qemu_img']} create -f qcow2 -F qcow2 -b", base, target]
-    run_cmd(cmd)
-  end
-
-  def create_command_file(cmd, filename)
-    path = "#{@workspace_path}/#{filename}.sh"
-    File.open(path, 'w') { |file| file.write(cmd) }
-    FileUtils.chmod('+x', path)
-  end
-
-  def normalize_paths
-    @config['images_path'].chomp!('/')
-    @config['virthck_path'].chomp!('/')
-  end
-
-  def validate_images
-    unless File.exist?("#{@config['images_path']}/#{@platform['st_image']}")
-      @logger.fatal('Studio image not found')
-      raise InvalidPathError
+    def client_snapshot(name)
+      filename = File.basename(@platform['clients'][name]['image'], '.*')
+      @workspace_path + '/' + filename + '-snapshot.qcow2'
     end
-    @platform['clients'].each_value do |client|
-      unless File.exist?("#{@config['images_path']}/#{client['image']}")
-        @logger.fatal("#{client['name']} image not found")
-        raise InvalidPathError
+
+    def platform_config(param)
+      default_value = @config['platforms_defaults'][param]
+      @platform[param] || default_value
+    end
+
+    def base_cmd
+      ["cd #{@config['virthck_path']} &&",
+       "sudo ./hck.sh ci_mode -id #{@id}",
+       "-world_bridge #{@config['dhcp_bridge']}",
+       "-qemu_bin #{@config['qemu_bin']}",
+       "-ivshmem_server_bin #{@config['ivshmem_server_bin']}",
+       "-fs_deamon_bin #{@config['fs_deamon_bin']}",
+       "-filesystem_tests_image #{@config['filesystem_tests_image']}",
+       "-ctrl_net_device #{platform_config('ctrl_net_device')}",
+       "-world_net_device #{platform_config('world_net_device')}",
+       "-viommu #{platform_config('viommu')}",
+       "-st_image #{studio_snapshot}"]
+    end
+
+    def device_cmd
+      ["-device_type #{@device['type']}",
+       !@device['name'].empty? ? "-device_name #{@device['name']}" : '',
+       !@device['extra'].empty? ? "-device_extra #{@device['extra']}" : '',
+       "-machine_type #{platform_config('machine_type')}",
+       "-s3 #{platform_config('s3')}",
+       "-s4 #{platform_config('s4')}",
+       "-enlightenments_state #{platform_config('enlightenments_state')}",
+       "-vhost_state #{platform_config('vhost_state')}"]
+    end
+
+    def client_cmd(name, client)
+      ["-#{name}_image #{client_snapshot(name)}",
+       "-#{name}_memory #{client['memory']}",
+       "-#{name}_cpus #{client['cpus']}"]
+    end
+
+    def clients_cmd
+      clients = []
+      @platform['clients'].each do |name, client|
+        clients += client_cmd(name, client)
+      end
+      clients
+    end
+
+    def retrieve_pid(pid_file)
+      Timeout.timeout(5) do
+        sleep 1 while File.zero?(pid_file.path)
+      end
+      pid_file.read.strip.to_i
+    rescue Timeout::Error
+      nil
+    end
+
+    def run(name, first_time = false)
+      sleep(rand(10))
+      temp_file do |pid|
+        cmd = base_cmd + clients_cmd + device_cmd +
+              ["-pidfile #{pid.path}", name]
+        create_command_file(cmd.join(' '), name) if first_time
+        run_cmd(cmd)
+        retrieve_pid(pid)
       end
     end
-  end
 
-  def create_studio
-    studio_ip = @project.config['ip_segment'] + @project.id.to_str
-    @studio = HCKStudio.new(@project, self, STUDIO, studio_ip)
-  end
+    def close
+      @logger.info('Cleanup host configurations')
+      cmd = base_cmd + device_cmd + ['end']
+      run_cmd(cmd)
+    end
 
-  def create_client(tag, name)
-    HCKClient.new(@project, self, @studio, tag, name)
-  end
+    def create_client_snapshot(name)
+      client = @platform['clients'][name]
+      @logger.info("Creating #{client['name']} snapshot file")
+      base = "#{@config['images_path']}/#{client['image']}"
+      target = client_snapshot(name)
+      create_snapshot_cmd(base, target)
+    end
 
-  def validate_paths
-    normalize_paths
-    validate_images
-    return if File.exist?("#{@config['virthck_path']}/hck.sh")
+    def delete_client_snapshot(name)
+      client = @platform['clients'][name]
+      @logger.info("Deleting #{client['name']} snapshot file")
+      target = client_snapshot(name)
+      FileUtils.rm_f(target)
+    end
 
-    @logger.fatal('VirtHCK path is not valid')
-    raise InvalidPathError
+    def create_studio_snapshot
+      @logger.info('Creating studio snapshot file')
+      base = "#{@config['images_path']}/#{@platform['st_image']}"
+      target = studio_snapshot
+      create_snapshot_cmd(base, target)
+    end
+
+    def delete_studio_snapshot
+      @logger.info('Deleting studio snapshot file')
+      target = studio_snapshot
+      FileUtils.rm_f(target)
+    end
+
+    def create_snapshot_cmd(base, target)
+      cmd = ["#{@config['qemu_img']} create -f qcow2 -F qcow2 -b", base, target]
+      run_cmd(cmd)
+    end
+
+    def create_command_file(cmd, filename)
+      path = "#{@workspace_path}/#{filename}.sh"
+      File.open(path, 'w') { |file| file.write(cmd) }
+      FileUtils.chmod('+x', path)
+    end
+
+    def normalize_paths
+      @config['images_path'].chomp!('/')
+      @config['virthck_path'].chomp!('/')
+    end
+
+    def validate_images
+      unless File.exist?("#{@config['images_path']}/#{@platform['st_image']}")
+        @logger.fatal('Studio image not found')
+        raise InvalidPathError
+      end
+      @platform['clients'].each_value do |client|
+        unless File.exist?("#{@config['images_path']}/#{client['image']}")
+          @logger.fatal("#{client['name']} image not found")
+          raise InvalidPathError
+        end
+      end
+    end
+
+    def create_studio
+      studio_ip = @project.config['ip_segment'] + @project.id.to_str
+      @studio = HCKStudio.new(@project, self, STUDIO, studio_ip)
+    end
+
+    def create_client(tag, name)
+      HCKClient.new(@project, self, @studio, tag, name)
+    end
+
+    def validate_paths
+      normalize_paths
+      validate_images
+      return if File.exist?("#{@config['virthck_path']}/hck.sh")
+
+      @logger.fatal('VirtHCK path is not valid')
+      raise InvalidPathError
+    end
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
-class AutoHCK
-  VERSION = '0.6.2'
+# AutoHCK module
+module AutoHCK
+  class AutoHCK
+    VERSION = '0.6.2'
+  end
 end


### PR DESCRIPTION
Initialization error of http_client class occurred on ruby
version 2.7. The root cause is Monitor class redefinition.
AutoHCK implements Monitor class for QEMU monitor communication,
but ruby also has a built-in Monitor class. To prevent the same
error with other classes, just use namespaces for our product.

Signed-off-by: Kostiantyn Kostiuk <konstantin@daynix.com>